### PR TITLE
Added JSDoc comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ts-markdown <!-- omit in toc -->
 
-> An extensible TypeScript markdown generator that takes JSON and creates a markdown document.
+An extensible TypeScript markdown generator that takes JSON and creates a markdown document.
 
 - [Getting Started](#getting-started)
 - [Usage](#usage)

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -28,6 +28,13 @@ import { textRenderer } from './renderers/text';
 import { ulRenderer } from './renderers/ul';
 import { Renderers } from './rendering.types';
 
+/**
+ * Provides default, custom, and overridden renderers for markdown rendering.
+ * This is often invoked when the caller wishes to provide custom renderers when rendering a markdown document.
+ *
+ * @param customRenderers Any renderers which should be used in addition to or in place of existing default renderers.
+ * @returns An object map of renderers where the key is the identifying property of the particular markdown entry type.
+ */
 export function getRenderers(customRenderers: Renderers = {}): Renderers {
   return {
     string: stringRenderer,

--- a/src/renderers/blockquote.ts
+++ b/src/renderers/blockquote.ts
@@ -2,10 +2,10 @@ import { getMarkdownString, renderEntries } from '../rendering';
 import { MarkdownRenderer, RenderOptions } from '../rendering.types';
 import { MarkdownEntry } from '../shared.types';
 
-export type BlockquoteEntry = {
+export interface BlockquoteEntry extends MarkdownEntry {
   blockquote: string | MarkdownEntry[];
   append?: string;
-} & MarkdownEntry;
+}
 
 export const blockquoteRenderer: MarkdownRenderer = (
   entry: BlockquoteEntry,

--- a/src/renderers/blockquote.ts
+++ b/src/renderers/blockquote.ts
@@ -19,6 +19,7 @@ export interface BlockquoteEntry extends MarkdownEntry {
 
 /**
  * The renderer for blockquote entries.
+ *
  * @param entry The blockquote entry.
  * @param options Document-level render options.
  * @returns Block-level blockquote markdown content.

--- a/src/renderers/blockquote.ts
+++ b/src/renderers/blockquote.ts
@@ -19,9 +19,9 @@ export interface BlockquoteEntry extends MarkdownEntry {
 
 /**
  * The renderer for blockquote entries.
- * @param entry The blockquote entry
- * @param options Document-level render option
- * @returns Block-level blockquote markdown content
+ * @param entry The blockquote entry.
+ * @param options Document-level render options.
+ * @returns Block-level blockquote markdown content.
  */
 export const blockquoteRenderer: MarkdownRenderer = (
   entry: BlockquoteEntry,

--- a/src/renderers/blockquote.ts
+++ b/src/renderers/blockquote.ts
@@ -2,11 +2,27 @@ import { getMarkdownString, renderEntries } from '../rendering';
 import { MarkdownRenderer, RenderOptions } from '../rendering.types';
 import { MarkdownEntry } from '../shared.types';
 
+/**
+ * A markdown entry for generating blockquotes.
+ */
 export interface BlockquoteEntry extends MarkdownEntry {
+  /**
+   * The blockquote contents and identifying property for the renderer.
+   */
   blockquote: string | MarkdownEntry[];
+
+  /**
+   * Option which will arbitrarily append a string immediately below the blockquote, ignoring block-level settings.
+   */
   append?: string;
 }
 
+/**
+ * The renderer for blockquote entries.
+ * @param entry The blockquote entry
+ * @param options Document-level render option
+ * @returns Block-level blockquote markdown content
+ */
 export const blockquoteRenderer: MarkdownRenderer = (
   entry: BlockquoteEntry,
   options: RenderOptions

--- a/src/renderers/bold.ts
+++ b/src/renderers/bold.ts
@@ -2,11 +2,10 @@ import { getMarkdownString } from '../rendering';
 import { RenderOptions, MarkdownRenderer } from '../rendering.types';
 import { MarkdownEntry, RichTextEntry } from '../shared.types';
 
-export type BoldEntry = {
+export interface BoldEntry extends MarkdownEntry, RichTextEntry {
   bold: RichTextEntry;
   indicator?: '*' | '_';
-} & MarkdownEntry &
-  RichTextEntry;
+}
 
 export const boldRenderer: MarkdownRenderer = (
   entry: BoldEntry,

--- a/src/renderers/bold.ts
+++ b/src/renderers/bold.ts
@@ -18,6 +18,7 @@ export interface BoldEntry extends MarkdownEntry, RichTextEntry {
 }
 
 /**
+ * The renderer for bold entries.
  *
  * @param entry The renderer for bolded entries.
  * @param options Document-level render options.

--- a/src/renderers/bold.ts
+++ b/src/renderers/bold.ts
@@ -2,11 +2,27 @@ import { getMarkdownString } from '../rendering';
 import { RenderOptions, MarkdownRenderer } from '../rendering.types';
 import { MarkdownEntry, RichTextEntry } from '../shared.types';
 
+/**
+ * A markdown entry for generating bolded text.
+ */
 export interface BoldEntry extends MarkdownEntry, RichTextEntry {
+  /**
+   * The bold text contents and identifying properyt for the renderer.
+   */
   bold: RichTextEntry;
+
+  /**
+   * The character which will be used to signify bolded text.
+   */
   indicator?: '*' | '_';
 }
 
+/**
+ *
+ * @param entry The renderer for bolded entries.
+ * @param options Document-level render options.
+ * @returns Bolded markdown content.
+ */
 export const boldRenderer: MarkdownRenderer = (
   entry: BoldEntry,
   options: RenderOptions

--- a/src/renderers/code.ts
+++ b/src/renderers/code.ts
@@ -1,9 +1,9 @@
 import { MarkdownRenderer, RenderOptions } from '../rendering.types';
 import { MarkdownEntry } from '../shared.types';
 
-export type CodeEntry = {
+export interface CodeEntry extends MarkdownEntry {
   code: string;
-} & MarkdownEntry;
+}
 
 export const codeRenderer: MarkdownRenderer = (
   entry: CodeEntry,

--- a/src/renderers/code.ts
+++ b/src/renderers/code.ts
@@ -1,10 +1,22 @@
 import { MarkdownRenderer, RenderOptions } from '../rendering.types';
 import { MarkdownEntry } from '../shared.types';
 
+/**
+ * A markdown entry for generating a code segment.
+ */
 export interface CodeEntry extends MarkdownEntry {
+  /**
+   * The code text.
+   */
   code: string;
 }
 
+/**
+ * The renderer for code entries.
+ * @param entry The code entry.
+ * @param options Document-level render options.
+ * @returns Code markdown content.
+ */
 export const codeRenderer: MarkdownRenderer = (
   entry: CodeEntry,
   options: RenderOptions

--- a/src/renderers/code.ts
+++ b/src/renderers/code.ts
@@ -13,6 +13,7 @@ export interface CodeEntry extends MarkdownEntry {
 
 /**
  * The renderer for code entries.
+ *
  * @param entry The code entry.
  * @param options Document-level render options.
  * @returns Code markdown content.

--- a/src/renderers/codeblock.ts
+++ b/src/renderers/codeblock.ts
@@ -1,13 +1,38 @@
 import { MarkdownRenderer, RenderOptions } from '../rendering.types';
 import { MarkdownEntry } from '../shared.types';
 
+/**
+ * A markdown entry for generating code blocks.
+ */
 export interface CodeBlockEntry extends MarkdownEntry {
+  /**
+   * The block of code, newlines included.
+   */
   codeblock: string | string[];
+
+  /**
+   * The character for signifying how to fence the code block.
+   * Leaving this blank results in the classic indented code block.
+   */
   fenced?: boolean | '`' | '~';
+
+  /**
+   * The code language, used for syntax highlighting in some markdown renderers.
+   */
   language?: string;
+
+  /**
+   * Option which will arbitrarily append a string immediately below the blockquote, ignoring block-level settings.
+   */
   append?: string;
 }
 
+/**
+ * The renderer for codeblock entries.
+ * @param entry The codeblock entry
+ * @param options Document-level render options
+ * @returns Block-level codeblock markdown content
+ */
 export const codeblockRenderer: MarkdownRenderer = (
   entry: CodeBlockEntry,
   options: RenderOptions

--- a/src/renderers/codeblock.ts
+++ b/src/renderers/codeblock.ts
@@ -29,6 +29,7 @@ export interface CodeBlockEntry extends MarkdownEntry {
 
 /**
  * The renderer for codeblock entries.
+ *
  * @param entry The codeblock entry
  * @param options Document-level render options
  * @returns Block-level codeblock markdown content

--- a/src/renderers/codeblock.ts
+++ b/src/renderers/codeblock.ts
@@ -1,12 +1,12 @@
 import { MarkdownRenderer, RenderOptions } from '../rendering.types';
 import { MarkdownEntry } from '../shared.types';
 
-export type CodeBlockEntry = {
+export interface CodeBlockEntry extends MarkdownEntry {
   codeblock: string | string[];
   fenced?: boolean | '`' | '~';
   language?: string;
   append?: string;
-} & MarkdownEntry;
+}
 
 export const codeblockRenderer: MarkdownRenderer = (
   entry: CodeBlockEntry,

--- a/src/renderers/dl.ts
+++ b/src/renderers/dl.ts
@@ -2,20 +2,53 @@ import { getMarkdownString } from '../rendering';
 import { MarkdownRenderer, RenderOptions } from '../rendering.types';
 import { MarkdownEntry, InlineTypes } from '../shared.types';
 
+/**
+ * A markdown entry for generating description lists.
+ */
 export interface DescriptionListEntry extends MarkdownEntry {
+  /**
+   * The description list contents and identifying property for the renderer.
+   */
   dl: (DescriptionTerm | DescriptionDetails)[];
+
+  /**
+   * Indicates whether to use HTML to render the entry.
+   * Default: false
+   */
   html?: boolean;
+
+  /**
+   * Option which will arbitrarily append a string immediately below the blockquote, ignoring block-level settings.
+   */
   append?: string;
 }
 
+/**
+ * A description term field.
+ */
 export type DescriptionTerm = {
+  /**
+   * The content of the description term.
+   */
   dt: InlineTypes;
 };
 
+/**
+ * A description details field.
+ */
 export type DescriptionDetails = {
+  /**
+   * The content of the details.
+   */
   dd: InlineTypes;
 };
 
+/**
+ * The renderer for descriptions list entries.
+ * @param entry The description list entry.
+ * @param options Document-level render options.
+ * @returns Block-level description list markdown content.
+ */
 export const dlRenderer: MarkdownRenderer = (
   entry: DescriptionListEntry,
   options: RenderOptions

--- a/src/renderers/dl.ts
+++ b/src/renderers/dl.ts
@@ -2,11 +2,11 @@ import { getMarkdownString } from '../rendering';
 import { MarkdownRenderer, RenderOptions } from '../rendering.types';
 import { MarkdownEntry, InlineTypes } from '../shared.types';
 
-export type DescriptionListEntry = {
+export interface DescriptionListEntry extends MarkdownEntry {
   dl: (DescriptionTerm | DescriptionDetails)[];
   html?: boolean;
   append?: string;
-} & MarkdownEntry;
+}
 
 export type DescriptionTerm = {
   dt: InlineTypes;

--- a/src/renderers/dl.ts
+++ b/src/renderers/dl.ts
@@ -45,6 +45,7 @@ export type DescriptionDetails = {
 
 /**
  * The renderer for descriptions list entries.
+ *
  * @param entry The description list entry.
  * @param options Document-level render options.
  * @returns Block-level description list markdown content.

--- a/src/renderers/emoji.ts
+++ b/src/renderers/emoji.ts
@@ -1,10 +1,22 @@
 import { MarkdownRenderer, RenderOptions } from '../rendering.types';
 import { MarkdownEntry, RichTextEntry } from '../shared.types';
 
+/**
+ * A markdown entry for generating emojis.
+ */
 export interface EmojiEntry extends MarkdownEntry, RichTextEntry {
+  /**
+   * The emoji name.
+   */
   emoji: string;
 }
 
+/**
+ * The renderer for emoji entries.
+ * @param entry The emoji entry.
+ * @param options Document-level render options.
+ * @returns Emoji markdown content.
+ */
 export const emojiRenderer: MarkdownRenderer = (
   entry: EmojiEntry,
   options: RenderOptions

--- a/src/renderers/emoji.ts
+++ b/src/renderers/emoji.ts
@@ -13,6 +13,7 @@ export interface EmojiEntry extends MarkdownEntry, RichTextEntry {
 
 /**
  * The renderer for emoji entries.
+ *
  * @param entry The emoji entry.
  * @param options Document-level render options.
  * @returns Emoji markdown content.

--- a/src/renderers/emoji.ts
+++ b/src/renderers/emoji.ts
@@ -1,10 +1,9 @@
 import { MarkdownRenderer, RenderOptions } from '../rendering.types';
 import { MarkdownEntry, RichTextEntry } from '../shared.types';
 
-export type EmojiEntry = {
+export interface EmojiEntry extends MarkdownEntry, RichTextEntry {
   emoji: string;
-} & MarkdownEntry &
-  RichTextEntry;
+}
 
 export const emojiRenderer: MarkdownRenderer = (
   entry: EmojiEntry,

--- a/src/renderers/footnote.ts
+++ b/src/renderers/footnote.ts
@@ -2,13 +2,33 @@ import { renderEntries } from '../rendering';
 import { MarkdownRenderer, RenderOptions } from '../rendering.types';
 import { MarkdownEntry, RichTextEntry } from '../shared.types';
 
+/**
+ * A markdown entry for generating footnotes.
+ */
 export interface FootnoteEntry extends MarkdownEntry, RichTextEntry {
+  /**
+   * The footnote contents and identifying property for the renderer.
+   */
   footnote: {
+    /**
+     * The footnote ID. This is used inline to signify which footnote to reference.
+     * Identifiers can be numbers or words, but they cannot contain spaces or tabs.
+     */
     id: string;
+
+    /**
+     * The footnote content to appear at the bottom of the document.
+     */
     content: MarkdownEntry | MarkdownEntry[];
   };
 }
 
+/**
+ * The renderer for footnote entries.
+ * @param entry The footnote entry.
+ * @param options Document-level render options.
+ * @returns Footnote ID markdown content.
+ */
 export const footnoteRenderer: MarkdownRenderer = (
   entry: FootnoteEntry,
   options: RenderOptions
@@ -20,6 +40,13 @@ export const footnoteRenderer: MarkdownRenderer = (
   throw new Error('Entry is not a footnote entry. Unable to render.');
 };
 
+/**
+ * The renderer for footnote content at the bottom of the document.
+ * @param data Content to include in the footnote.
+ * @param document The document to update.
+ * @param options Document-level options.
+ * @returns The updated document.
+ */
 export function appendFootnotes(
   data: MarkdownEntry[],
   document: string,

--- a/src/renderers/footnote.ts
+++ b/src/renderers/footnote.ts
@@ -2,13 +2,12 @@ import { renderEntries } from '../rendering';
 import { MarkdownRenderer, RenderOptions } from '../rendering.types';
 import { MarkdownEntry, RichTextEntry } from '../shared.types';
 
-export type FootnoteEntry = {
+export interface FootnoteEntry extends MarkdownEntry, RichTextEntry {
   footnote: {
     id: string;
     content: MarkdownEntry | MarkdownEntry[];
   };
-} & MarkdownEntry &
-  RichTextEntry;
+}
 
 export const footnoteRenderer: MarkdownRenderer = (
   entry: FootnoteEntry,

--- a/src/renderers/footnote.ts
+++ b/src/renderers/footnote.ts
@@ -25,6 +25,7 @@ export interface FootnoteEntry extends MarkdownEntry, RichTextEntry {
 
 /**
  * The renderer for footnote entries.
+ *
  * @param entry The footnote entry.
  * @param options Document-level render options.
  * @returns Footnote ID markdown content.
@@ -42,6 +43,7 @@ export const footnoteRenderer: MarkdownRenderer = (
 
 /**
  * The renderer for footnote content at the bottom of the document.
+ *
  * @param data Content to include in the footnote.
  * @param document The document to update.
  * @param options Document-level options.

--- a/src/renderers/h1.test.ts
+++ b/src/renderers/h1.test.ts
@@ -66,14 +66,14 @@ describe('given a header 1 entry', () => {
           'The magnificent power of ',
           {
             link: {
-              source: 'https://www.google.com',
+              href: 'https://www.google.com',
               text: 'Googling Placeholders',
             },
           },
           ' like ',
           {
             img: {
-              href: 'https://via.placeholder.com/25',
+              source: 'https://via.placeholder.com/25',
               alt: 'A 25x25 placeholder image',
               title: 'Here is a handy placeholder image',
             },

--- a/src/renderers/h1.ts
+++ b/src/renderers/h1.ts
@@ -3,13 +3,39 @@ import { getOptionalHeaderIdText } from './header';
 import { RenderOptions, MarkdownRenderer } from '../rendering.types';
 import { InlineTypes, MarkdownEntry } from '../shared.types';
 
+/**
+ * A markdown entry for generating h1 elements.
+ */
 export interface H1Entry extends MarkdownEntry {
+  /**
+   * The h1 contents and identifying property for the renderer.
+   */
   h1: InlineTypes;
+
+  /**
+   * Option which will use '=' underlining rather than a '#' prefix.
+   */
   underline?: boolean;
+
+  /**
+   * Option which will append a markdown heading ID.
+   * E.g., given the ID 'my-id' and the header 'Header Example',
+   * `# Header Example {#my-id}`
+   */
   id?: string;
+
+  /**
+   * Option which will arbitrarily append a string immediately below the h1, ignoring block-level settings.
+   */
   append?: string;
 }
 
+/**
+ * The renderer for h1 entries.
+ * @param entry The h1 entry.
+ * @param options Document-level render options.
+ * @returns Block-level h1 markdown content.
+ */
 export const h1Renderer: MarkdownRenderer = (
   entry: H1Entry,
   options: RenderOptions

--- a/src/renderers/h1.ts
+++ b/src/renderers/h1.ts
@@ -46,7 +46,7 @@ export const h1Renderer: MarkdownRenderer = (
     let headerText = `${header1IndicatorPrefix}${getMarkdownString(
       entry.h1,
       options
-    )}${getOptionalHeaderIdText(entry, ' ')}`;
+    )}${getOptionalHeaderIdText(entry.id, ' ')}`;
 
     if (useUnderlining) {
       headerText += '\n' + ''.padEnd(headerText.length, '=');

--- a/src/renderers/h1.ts
+++ b/src/renderers/h1.ts
@@ -32,6 +32,7 @@ export interface H1Entry extends MarkdownEntry {
 
 /**
  * The renderer for h1 entries.
+ *
  * @param entry The h1 entry.
  * @param options Document-level render options.
  * @returns Block-level h1 markdown content.

--- a/src/renderers/h1.ts
+++ b/src/renderers/h1.ts
@@ -3,12 +3,12 @@ import { getOptionalHeaderIdText } from './header';
 import { RenderOptions, MarkdownRenderer } from '../rendering.types';
 import { InlineTypes, MarkdownEntry } from '../shared.types';
 
-export type H1Entry = {
+export interface H1Entry extends MarkdownEntry {
   h1: InlineTypes;
   underline?: boolean;
   id?: string;
   append?: string;
-} & MarkdownEntry;
+}
 
 export const h1Renderer: MarkdownRenderer = (
   entry: H1Entry,

--- a/src/renderers/h2.test.ts
+++ b/src/renderers/h2.test.ts
@@ -66,14 +66,14 @@ describe('given a header 2 entry', () => {
           'The magnificent power of ',
           {
             link: {
-              source: 'https://www.google.com',
+              href: 'https://www.google.com',
               text: 'Googling Placeholders',
             },
           },
           ' like ',
           {
             img: {
-              href: 'https://via.placeholder.com/25',
+              source: 'https://via.placeholder.com/25',
               alt: 'A 25x25 placeholder image',
               title: 'Here is a handy placeholder image',
             },

--- a/src/renderers/h2.ts
+++ b/src/renderers/h2.ts
@@ -3,13 +3,39 @@ import { getOptionalHeaderIdText } from './header';
 import { RenderOptions, MarkdownRenderer } from '../rendering.types';
 import { InlineTypes, MarkdownEntry } from '../shared.types';
 
+/**
+ * A markdown entry for generating h2 elements.
+ */
 export interface H2Entry extends MarkdownEntry {
+  /**
+   * The h2 contents and identifying property for the renderer.
+   */
   h2: InlineTypes;
+
+  /**
+   * Option which will use '-' underlining rather than a '#' prefix.
+   */
   underline?: boolean;
+
+  /**
+   * Option which will append a markdown heading ID.
+   * E.g., given the ID 'my-id' and the header 'Header Example',
+   * `## Header Example {#my-id}`
+   */
   id?: string;
+
+  /**
+   * Option which will arbitrarily append a string immediately below the h2, ignoring block-level settings.
+   */
   append?: string;
 }
 
+/**
+ * The renderer for h2 entries.
+ * @param entry The h2 entry.
+ * @param options Document-level render options.
+ * @returns Block-level h2 markdown content.
+ */
 export const h2Renderer: MarkdownRenderer = (
   entry: H2Entry,
   options: RenderOptions

--- a/src/renderers/h2.ts
+++ b/src/renderers/h2.ts
@@ -32,6 +32,7 @@ export interface H2Entry extends MarkdownEntry {
 
 /**
  * The renderer for h2 entries.
+ *
  * @param entry The h2 entry.
  * @param options Document-level render options.
  * @returns Block-level h2 markdown content.

--- a/src/renderers/h2.ts
+++ b/src/renderers/h2.ts
@@ -3,12 +3,12 @@ import { getOptionalHeaderIdText } from './header';
 import { RenderOptions, MarkdownRenderer } from '../rendering.types';
 import { InlineTypes, MarkdownEntry } from '../shared.types';
 
-export type H2Entry = {
+export interface H2Entry extends MarkdownEntry {
   h2: InlineTypes;
   underline?: boolean;
   id?: string;
   append?: string;
-} & MarkdownEntry;
+}
 
 export const h2Renderer: MarkdownRenderer = (
   entry: H2Entry,

--- a/src/renderers/h2.ts
+++ b/src/renderers/h2.ts
@@ -13,7 +13,7 @@ export interface H2Entry extends MarkdownEntry {
   h2: InlineTypes;
 
   /**
-   * Option which will use '-' underlining rather than a '#' prefix.
+   * Option which will use '-' underlining rather than a '##' prefix.
    */
   underline?: boolean;
 

--- a/src/renderers/h2.ts
+++ b/src/renderers/h2.ts
@@ -46,7 +46,7 @@ export const h2Renderer: MarkdownRenderer = (
     let headerText = `${header2IndicatorPrefix}${getMarkdownString(
       entry.h2,
       options
-    )}${getOptionalHeaderIdText(entry, ' ')}`;
+    )}${getOptionalHeaderIdText(entry.id, ' ')}`;
 
     if (useUnderlining) {
       headerText += '\n' + ''.padEnd(headerText.length, '-');

--- a/src/renderers/h3.test.ts
+++ b/src/renderers/h3.test.ts
@@ -68,14 +68,14 @@ describe('given a header 3 entry', () => {
           'The magnificent power of ',
           {
             link: {
-              source: 'https://www.google.com',
+              href: 'https://www.google.com',
               text: 'Googling Placeholders',
             },
           },
           ' like ',
           {
             img: {
-              href: 'https://via.placeholder.com/25',
+              source: 'https://via.placeholder.com/25',
               alt: 'A 25x25 placeholder image',
               title: 'Here is a handy placeholder image',
             },

--- a/src/renderers/h3.ts
+++ b/src/renderers/h3.ts
@@ -27,6 +27,7 @@ export interface H3Entry extends MarkdownEntry {
 
 /**
  * The renderer for h3 entries.
+ *
  * @param entry The h3 entry.
  * @param options Document-level render options.
  * @returns Block-level h3 markdown content.

--- a/src/renderers/h3.ts
+++ b/src/renderers/h3.ts
@@ -3,11 +3,11 @@ import { getOptionalHeaderIdText } from './header';
 import { RenderOptions, MarkdownRenderer } from '../rendering.types';
 import { InlineTypes, MarkdownEntry } from '../shared.types';
 
-export type H3Entry = {
+export interface H3Entry extends MarkdownEntry {
   h3: InlineTypes;
   id?: string;
   append?: string;
-} & MarkdownEntry;
+}
 
 export const h3Renderer: MarkdownRenderer = (
   entry: H3Entry,

--- a/src/renderers/h3.ts
+++ b/src/renderers/h3.ts
@@ -3,12 +3,34 @@ import { getOptionalHeaderIdText } from './header';
 import { RenderOptions, MarkdownRenderer } from '../rendering.types';
 import { InlineTypes, MarkdownEntry } from '../shared.types';
 
+/**
+ * A markdown entry for generating h3 elements.
+ */
 export interface H3Entry extends MarkdownEntry {
+  /**
+   * The h3 contents and identifying property for the renderer.
+   */
   h3: InlineTypes;
+
+  /**
+   * Option which will append a markdown heading ID.
+   * E.g., given the ID 'my-id' and the header 'Header Example',
+   * `### Header Example {#my-id}`
+   */
   id?: string;
+
+  /**
+   * Option which will arbitrarily append a string immediately below the h3, ignoring block-level settings.
+   */
   append?: string;
 }
 
+/**
+ * The renderer for h3 entries.
+ * @param entry The h3 entry.
+ * @param options Document-level render options.
+ * @returns Block-level h3 markdown content.
+ */
 export const h3Renderer: MarkdownRenderer = (
   entry: H3Entry,
   options: RenderOptions

--- a/src/renderers/h3.ts
+++ b/src/renderers/h3.ts
@@ -39,7 +39,7 @@ export const h3Renderer: MarkdownRenderer = (
     let headerText = `### ${getMarkdownString(
       entry.h3,
       options
-    )}${getOptionalHeaderIdText(entry, ' ')}`;
+    )}${getOptionalHeaderIdText(entry.id, ' ')}`;
 
     return {
       markdown: headerText,

--- a/src/renderers/h4.test.ts
+++ b/src/renderers/h4.test.ts
@@ -68,14 +68,14 @@ describe('given a header 4 entry', () => {
           'The magnificent power of ',
           {
             link: {
-              source: 'https://www.google.com',
+              href: 'https://www.google.com',
               text: 'Googling Placeholders',
             },
           },
           ' like ',
           {
             img: {
-              href: 'https://via.placeholder.com/25',
+              source: 'https://via.placeholder.com/25',
               alt: 'A 25x25 placeholder image',
               title: 'Here is a handy placeholder image',
             },

--- a/src/renderers/h4.ts
+++ b/src/renderers/h4.ts
@@ -3,12 +3,34 @@ import { getOptionalHeaderIdText } from './header';
 import { RenderOptions, MarkdownRenderer } from '../rendering.types';
 import { InlineTypes, MarkdownEntry } from '../shared.types';
 
+/**
+ * A markdown entry for generating h4 elements.
+ */
 export interface H4Entry extends MarkdownEntry {
+  /**
+   * The h4 contents and identifying property for the renderer.
+   */
   h4: InlineTypes;
+
+  /**
+   * Option which will append a markdown heading ID.
+   * E.g., given the ID 'my-id' and the header 'Header Example',
+   * `#### Header Example {#my-id}`
+   */
   id?: string;
+
+  /**
+   * Option which will arbitrarily append a string immediately below the h4, ignoring block-level settings.
+   */
   append?: string;
 }
 
+/**
+ * The renderer for h4 entries.
+ * @param entry The h4 entry.
+ * @param options Document-level render options.
+ * @returns Block-level h4 markdown content.
+ */
 export const h4Renderer: MarkdownRenderer = (
   entry: H4Entry,
   options: RenderOptions

--- a/src/renderers/h4.ts
+++ b/src/renderers/h4.ts
@@ -27,6 +27,7 @@ export interface H4Entry extends MarkdownEntry {
 
 /**
  * The renderer for h4 entries.
+ *
  * @param entry The h4 entry.
  * @param options Document-level render options.
  * @returns Block-level h4 markdown content.

--- a/src/renderers/h4.ts
+++ b/src/renderers/h4.ts
@@ -3,11 +3,11 @@ import { getOptionalHeaderIdText } from './header';
 import { RenderOptions, MarkdownRenderer } from '../rendering.types';
 import { InlineTypes, MarkdownEntry } from '../shared.types';
 
-export type H4Entry = {
+export interface H4Entry extends MarkdownEntry {
   h4: InlineTypes;
   id?: string;
   append?: string;
-} & MarkdownEntry;
+}
 
 export const h4Renderer: MarkdownRenderer = (
   entry: H4Entry,

--- a/src/renderers/h4.ts
+++ b/src/renderers/h4.ts
@@ -39,7 +39,7 @@ export const h4Renderer: MarkdownRenderer = (
     let headerText = `#### ${getMarkdownString(
       entry.h4,
       options
-    )}${getOptionalHeaderIdText(entry, ' ')}`;
+    )}${getOptionalHeaderIdText(entry.id, ' ')}`;
 
     return {
       markdown: headerText,

--- a/src/renderers/h5.test.ts
+++ b/src/renderers/h5.test.ts
@@ -68,14 +68,14 @@ describe('given a header 5 entry', () => {
           'The magnificent power of ',
           {
             link: {
-              source: 'https://www.google.com',
+              href: 'https://www.google.com',
               text: 'Googling Placeholders',
             },
           },
           ' like ',
           {
             img: {
-              href: 'https://via.placeholder.com/25',
+              source: 'https://via.placeholder.com/25',
               alt: 'A 25x25 placeholder image',
               title: 'Here is a handy placeholder image',
             },

--- a/src/renderers/h5.ts
+++ b/src/renderers/h5.ts
@@ -3,11 +3,11 @@ import { getOptionalHeaderIdText } from './header';
 import { RenderOptions, MarkdownRenderer } from '../rendering.types';
 import { InlineTypes, MarkdownEntry } from '../shared.types';
 
-export type H5Entry = {
+export interface H5Entry extends MarkdownEntry {
   h5: InlineTypes;
   id?: string;
   append?: string;
-} & MarkdownEntry;
+}
 
 export const h5Renderer: MarkdownRenderer = (
   entry: H5Entry,

--- a/src/renderers/h5.ts
+++ b/src/renderers/h5.ts
@@ -3,12 +3,34 @@ import { getOptionalHeaderIdText } from './header';
 import { RenderOptions, MarkdownRenderer } from '../rendering.types';
 import { InlineTypes, MarkdownEntry } from '../shared.types';
 
+/**
+ * A markdown entry for generating h5 elements.
+ */
 export interface H5Entry extends MarkdownEntry {
+  /**
+   * The h5 contents and identifying property for the renderer.
+   */
   h5: InlineTypes;
+
+  /**
+   * Option which will append a markdown heading ID.
+   * E.g., given the ID 'my-id' and the header 'Header Example',
+   * `##### Header Example {#my-id}`
+   */
   id?: string;
+
+  /**
+   * Option which will arbitrarily append a string immediately below the h5, ignoring block-level settings.
+   */
   append?: string;
 }
 
+/**
+ * The renderer for h5 entries.
+ * @param entry The h5 entry.
+ * @param options Document-level render options.
+ * @returns Block-level h5 markdown content.
+ */
 export const h5Renderer: MarkdownRenderer = (
   entry: H5Entry,
   options: RenderOptions

--- a/src/renderers/h5.ts
+++ b/src/renderers/h5.ts
@@ -39,7 +39,7 @@ export const h5Renderer: MarkdownRenderer = (
     let headerText = `##### ${getMarkdownString(
       entry.h5,
       options
-    )}${getOptionalHeaderIdText(entry, ' ')}`;
+    )}${getOptionalHeaderIdText(entry.id, ' ')}`;
 
     return {
       markdown: headerText,

--- a/src/renderers/h5.ts
+++ b/src/renderers/h5.ts
@@ -27,6 +27,7 @@ export interface H5Entry extends MarkdownEntry {
 
 /**
  * The renderer for h5 entries.
+ *
  * @param entry The h5 entry.
  * @param options Document-level render options.
  * @returns Block-level h5 markdown content.

--- a/src/renderers/h6.test.ts
+++ b/src/renderers/h6.test.ts
@@ -70,14 +70,14 @@ describe('given a header 6 entry', () => {
           'The magnificent power of ',
           {
             link: {
-              source: 'https://www.google.com',
+              href: 'https://www.google.com',
               text: 'Googling Placeholders',
             },
           },
           ' like ',
           {
             img: {
-              href: 'https://via.placeholder.com/25',
+              source: 'https://via.placeholder.com/25',
               alt: 'A 25x25 placeholder image',
               title: 'Here is a handy placeholder image',
             },

--- a/src/renderers/h6.ts
+++ b/src/renderers/h6.ts
@@ -3,12 +3,34 @@ import { getOptionalHeaderIdText } from './header';
 import { RenderOptions, MarkdownRenderer } from '../rendering.types';
 import { InlineTypes, MarkdownEntry } from '../shared.types';
 
+/**
+ * A markdown entry for generating h6 elements.
+ */
 export interface H6Entry extends MarkdownEntry {
+  /**
+   * The h6 contents and identifying property for the renderer.
+   */
   h6: InlineTypes;
+
+  /**
+   * Option which will append a markdown heading ID.
+   * E.g., given the ID 'my-id' and the header 'Header Example',
+   * `###### Header Example {#my-id}`
+   */
   id?: string;
+
+  /**
+   * Option which will arbitrarily append a string immediately below the h6, ignoring block-level settings.
+   */
   append?: string;
 }
 
+/**
+ * The renderer for h6 entries.
+ * @param entry The h6 entry.
+ * @param options Document-level render options.
+ * @returns Block-level h6 markdown content.
+ */
 export const h6Renderer: MarkdownRenderer = (
   entry: H6Entry,
   options: RenderOptions

--- a/src/renderers/h6.ts
+++ b/src/renderers/h6.ts
@@ -27,6 +27,7 @@ export interface H6Entry extends MarkdownEntry {
 
 /**
  * The renderer for h6 entries.
+ *
  * @param entry The h6 entry.
  * @param options Document-level render options.
  * @returns Block-level h6 markdown content.

--- a/src/renderers/h6.ts
+++ b/src/renderers/h6.ts
@@ -3,11 +3,11 @@ import { getOptionalHeaderIdText } from './header';
 import { RenderOptions, MarkdownRenderer } from '../rendering.types';
 import { InlineTypes, MarkdownEntry } from '../shared.types';
 
-export type H6Entry = {
+export interface H6Entry extends MarkdownEntry {
   h6: InlineTypes;
   id?: string;
   append?: string;
-} & MarkdownEntry;
+}
 
 export const h6Renderer: MarkdownRenderer = (
   entry: H6Entry,

--- a/src/renderers/h6.ts
+++ b/src/renderers/h6.ts
@@ -39,7 +39,7 @@ export const h6Renderer: MarkdownRenderer = (
     let headerText = `###### ${getMarkdownString(
       entry.h6,
       options
-    )}${getOptionalHeaderIdText(entry, ' ')}`;
+    )}${getOptionalHeaderIdText(entry.id, ' ')}`;
 
     return {
       markdown: headerText,

--- a/src/renderers/header.ts
+++ b/src/renderers/header.ts
@@ -1,10 +1,9 @@
-export function getOptionalHeaderIdText(
-  entry: { id?: string },
-  prefix: string = ''
-) {
-  if (entry.id === undefined) {
-    return '';
-  }
-
-  return `${prefix}{#${entry.id}}`;
+/**
+ * Appends a heading with an ID.
+ * @param id The ID. Can also be null or undefined.
+ * @param prefix Any prefix text that should be prepended to the resulting ID markdown.
+ * @returns A header with ID markdown appended, or an empty string.
+ */
+export function getOptionalHeaderIdText(id?: string, prefix: string = '') {
+  return id !== undefined ? `${prefix}{#${id}}` : '';
 }

--- a/src/renderers/header.ts
+++ b/src/renderers/header.ts
@@ -1,5 +1,6 @@
 /**
  * Appends a heading with an ID.
+ *
  * @param id The ID. Can also be null or undefined.
  * @param prefix Any prefix text that should be prepended to the resulting ID markdown.
  * @returns A header with ID markdown appended, or an empty string.

--- a/src/renderers/highlight.ts
+++ b/src/renderers/highlight.ts
@@ -2,10 +2,9 @@ import { getMarkdownString } from '../rendering';
 import { RenderOptions, MarkdownRenderer } from '../rendering.types';
 import { RichTextEntry, MarkdownEntry } from '../shared.types';
 
-export type HighlightEntry = {
+export interface HighlightEntry extends MarkdownEntry, RichTextEntry {
   highlight: RichTextEntry;
-} & MarkdownEntry &
-  RichTextEntry;
+}
 
 export const highlightRenderer: MarkdownRenderer = (
   entry: HighlightEntry,

--- a/src/renderers/highlight.ts
+++ b/src/renderers/highlight.ts
@@ -14,6 +14,7 @@ export interface HighlightEntry extends MarkdownEntry, RichTextEntry {
 
 /**
  * The renderer for highlight entries.
+ *
  * @param entry The highlight entry.
  * @param options Document-level render options.
  * @returns Hihglighted text markdown content.

--- a/src/renderers/highlight.ts
+++ b/src/renderers/highlight.ts
@@ -2,10 +2,22 @@ import { getMarkdownString } from '../rendering';
 import { RenderOptions, MarkdownRenderer } from '../rendering.types';
 import { RichTextEntry, MarkdownEntry } from '../shared.types';
 
+/**
+ * A markdown entry for generating highlighted text.
+ */
 export interface HighlightEntry extends MarkdownEntry, RichTextEntry {
+  /**
+   * The highlighted contents and identifying property for the renderer.
+   */
   highlight: RichTextEntry;
 }
 
+/**
+ * The renderer for highlight entries.
+ * @param entry The highlight entry.
+ * @param options Document-level render options.
+ * @returns Hihglighted text markdown content.
+ */
 export const highlightRenderer: MarkdownRenderer = (
   entry: HighlightEntry,
   options: RenderOptions

--- a/src/renderers/hr.ts
+++ b/src/renderers/hr.ts
@@ -1,12 +1,33 @@
 import { MarkdownRenderer, RenderOptions } from '../rendering.types';
 import { MarkdownEntry } from '../shared.types';
 
+/**
+ * A markdown entry for generating hr elements.
+ */
 export interface HorizontalRuleEntry extends MarkdownEntry {
+  /**
+   * The hr contents and identifying property for the renderer.
+   */
   hr: any;
+
+  /**
+   * Option determining which indicator to use for an hr.
+   * Default: '-'
+   */
   indicator?: '*' | '-' | '_';
+
+  /**
+   * Option which will arbitrarily append a string immediately below the hr, ignoring block-level settings.
+   */
   append?: string;
 }
 
+/**
+ * The renderer for hr entries.
+ * @param entry The hr entry.
+ * @param options Document-level render options.
+ * @returns Block-level hr markdown content.
+ */
 export const hrRenderer: MarkdownRenderer = (
   entry: HorizontalRuleEntry,
   options: RenderOptions

--- a/src/renderers/hr.ts
+++ b/src/renderers/hr.ts
@@ -1,11 +1,11 @@
 import { MarkdownRenderer, RenderOptions } from '../rendering.types';
 import { MarkdownEntry } from '../shared.types';
 
-export type HorizontalRuleEntry = {
+export interface HorizontalRuleEntry extends MarkdownEntry {
   hr: any;
   indicator?: '*' | '-' | '_';
   append?: string;
-} & MarkdownEntry;
+}
 
 export const hrRenderer: MarkdownRenderer = (
   entry: HorizontalRuleEntry,

--- a/src/renderers/hr.ts
+++ b/src/renderers/hr.ts
@@ -24,6 +24,7 @@ export interface HorizontalRuleEntry extends MarkdownEntry {
 
 /**
  * The renderer for hr entries.
+ *
  * @param entry The hr entry.
  * @param options Document-level render options.
  * @returns Block-level hr markdown content.

--- a/src/renderers/img.test.ts
+++ b/src/renderers/img.test.ts
@@ -5,26 +5,26 @@ describe('given an image entry', () => {
   describe('with an href', () => {
     const imgEntry: ImageEntry = {
       img: {
-        href: 'image.png',
+        source: 'image.png',
       },
     };
 
     test('renders an image line with the specified href', () => {
-      expect(tsMarkdown([imgEntry])).toBe(`![](${imgEntry.img.href})`);
+      expect(tsMarkdown([imgEntry])).toBe(`![](${imgEntry.img.source})`);
     });
   });
 
   describe('with an href and alt text', () => {
     const imgEntry: ImageEntry = {
       img: {
-        href: 'image.png',
+        source: 'image.png',
         alt: 'Alt text here',
       },
     };
 
     test('renders an image line with the specified href and alt text', () => {
       expect(tsMarkdown([imgEntry])).toBe(
-        `![${imgEntry.img.alt}](${imgEntry.img.href})`
+        `![${imgEntry.img.alt}](${imgEntry.img.source})`
       );
     });
   });
@@ -32,7 +32,7 @@ describe('given an image entry', () => {
   describe('with an href, title, and alt text', () => {
     const imgEntry: ImageEntry = {
       img: {
-        href: 'image.png',
+        source: 'image.png',
         alt: 'Alt text here',
         title: 'Title here',
       },
@@ -40,7 +40,7 @@ describe('given an image entry', () => {
 
     test('renders an image line with the specified href and alt text', () => {
       expect(tsMarkdown([imgEntry])).toBe(
-        `![${imgEntry.img.alt}](${imgEntry.img.href} "${imgEntry.img.title}")`
+        `![${imgEntry.img.alt}](${imgEntry.img.source} "${imgEntry.img.title}")`
       );
     });
   });

--- a/src/renderers/img.ts
+++ b/src/renderers/img.ts
@@ -1,20 +1,43 @@
 import { MarkdownRenderer, RenderOptions } from '../rendering.types';
 import { MarkdownEntry } from '../shared.types';
 
+/**
+ * A markdown entry for generating img elements.
+ */
 export interface ImageEntry extends MarkdownEntry {
+  /**
+   * The img settings and identifying property for the renderer.
+   */
   img: {
-    href: string;
+    /**
+     * The path to the image.
+     */
+    source: string;
+
+    /**
+     * Alternative text to include with the image for accessibility.
+     */
     alt?: string;
+
+    /**
+     * A title for the image.
+     */
     title?: string;
   };
 }
 
+/**
+ * The renderer for img entries.
+ * @param entry The img entry.
+ * @param options Document-level render options.
+ * @returns img markdown content.
+ */
 export const imgRenderer: MarkdownRenderer = (
   entry: ImageEntry,
   options: RenderOptions
 ) => {
   if ('img' in entry) {
-    const formattedLink = entry.img.href.replace(/\s/g, '%20');
+    const formattedLink = entry.img.source.replace(/\s/g, '%20');
 
     const titleSegment =
       entry.img.title !== undefined ? ` "${entry.img.title}"` : '';

--- a/src/renderers/img.ts
+++ b/src/renderers/img.ts
@@ -28,6 +28,7 @@ export interface ImageEntry extends MarkdownEntry {
 
 /**
  * The renderer for img entries.
+ *
  * @param entry The img entry.
  * @param options Document-level render options.
  * @returns img markdown content.

--- a/src/renderers/img.ts
+++ b/src/renderers/img.ts
@@ -1,13 +1,13 @@
 import { MarkdownRenderer, RenderOptions } from '../rendering.types';
 import { MarkdownEntry } from '../shared.types';
 
-export type ImageEntry = {
+export interface ImageEntry extends MarkdownEntry {
   img: {
     href: string;
     alt?: string;
     title?: string;
   };
-} & MarkdownEntry;
+}
 
 export const imgRenderer: MarkdownRenderer = (
   entry: ImageEntry,

--- a/src/renderers/italic.ts
+++ b/src/renderers/italic.ts
@@ -20,6 +20,7 @@ export interface ItalicEntry extends MarkdownEntry, RichTextEntry {
 
 /**
  * The renderer for italic entries.
+ *
  * @param entry The italic entry.
  * @param options Document-level render options.
  * @returns Italic markdown content.

--- a/src/renderers/italic.ts
+++ b/src/renderers/italic.ts
@@ -2,11 +2,28 @@ import { getMarkdownString } from '../rendering';
 import { RenderOptions, MarkdownRenderer } from '../rendering.types';
 import { RichTextEntry, MarkdownEntry } from '../shared.types';
 
+/**
+ * A markdown entry for generating italic text.
+ */
 export interface ItalicEntry extends MarkdownEntry, RichTextEntry {
+  /**
+   * The italic text contents and identifying property for the renderer.
+   */
   italic: RichTextEntry;
+
+  /**
+   * Indicator determining what character is used to denote italics.
+   * Default: '*'
+   */
   indicator?: '*' | '_';
 }
 
+/**
+ * The renderer for italic entries.
+ * @param entry The italic entry.
+ * @param options Document-level render options.
+ * @returns Italic markdown content.
+ */
 export const italicRenderer: MarkdownRenderer = (
   entry: ItalicEntry,
   options: RenderOptions

--- a/src/renderers/italic.ts
+++ b/src/renderers/italic.ts
@@ -2,11 +2,10 @@ import { getMarkdownString } from '../rendering';
 import { RenderOptions, MarkdownRenderer } from '../rendering.types';
 import { RichTextEntry, MarkdownEntry } from '../shared.types';
 
-export type ItalicEntry = {
+export interface ItalicEntry extends MarkdownEntry, RichTextEntry {
   italic: RichTextEntry;
   indicator?: '*' | '_';
-} & MarkdownEntry &
-  RichTextEntry;
+}
 
 export const italicRenderer: MarkdownRenderer = (
   entry: ItalicEntry,

--- a/src/renderers/link.test.ts
+++ b/src/renderers/link.test.ts
@@ -4,22 +4,22 @@ import { LinkEntry } from './link';
 describe('given a link entry', () => {
   describe('with no text', () => {
     const linkEntry: LinkEntry = {
-      link: { source: 'https://www.google.com' },
+      link: { href: 'https://www.google.com' },
     };
 
     test('renders an auto-link', () => {
-      expect(tsMarkdown([linkEntry])).toBe(`<${linkEntry.link.source}>`);
+      expect(tsMarkdown([linkEntry])).toBe(`<${linkEntry.link.href}>`);
     });
   });
 
   describe('with source and text', () => {
     const linkEntry: LinkEntry = {
-      link: { source: 'https://www.google.com', text: 'Google' },
+      link: { href: 'https://www.google.com', text: 'Google' },
     };
 
     test('renders a link line with specified text and source', () => {
       expect(tsMarkdown([linkEntry])).toBe(
-        `[${linkEntry.link.text}](${linkEntry.link.source})`
+        `[${linkEntry.link.text}](${linkEntry.link.href})`
       );
     });
   });
@@ -27,7 +27,7 @@ describe('given a link entry', () => {
   describe('with source, text, and title', () => {
     const linkEntry: LinkEntry = {
       link: {
-        source: 'https://www.google.com',
+        href: 'https://www.google.com',
         text: 'Google',
         title: 'Let Me Google That For You...',
       },
@@ -35,7 +35,7 @@ describe('given a link entry', () => {
 
     test('renders a link line with specified text and source', () => {
       expect(tsMarkdown([linkEntry])).toBe(
-        `[${linkEntry.link.text}](${linkEntry.link.source} "${linkEntry.link.title}")`
+        `[${linkEntry.link.text}](${linkEntry.link.href} "${linkEntry.link.title}")`
       );
     });
   });
@@ -46,13 +46,13 @@ describe('given a link entry', () => {
   describe('with source that has spaces', () => {
     const linkEntry: LinkEntry = {
       link: {
-        source: 'https://www.google.com/this is my cool link',
+        href: 'https://www.google.com/this is my cool link',
       },
     };
 
     test('renders an auto-link with spaces URL-encoded', () => {
       expect(tsMarkdown([linkEntry])).toBe(
-        `<${linkEntry.link.source.replace(/\s/g, '%20')}>`
+        `<${linkEntry.link.href.replace(/\s/g, '%20')}>`
       );
     });
   });
@@ -63,17 +63,14 @@ describe('given a link entry', () => {
   describe('with source that has spaces and text', () => {
     const linkEntry: LinkEntry = {
       link: {
-        source: 'https://www.google.com/this is my cool link',
+        href: 'https://www.google.com/this is my cool link',
         text: 'Not a cool link',
       },
     };
 
     test('renders a link line with spaces URL-encoded on the source', () => {
       expect(tsMarkdown([linkEntry])).toBe(
-        `[${linkEntry.link.text}](${linkEntry.link.source.replace(
-          /\s/g,
-          '%20'
-        )})`
+        `[${linkEntry.link.text}](${linkEntry.link.href.replace(/\s/g, '%20')})`
       );
     });
   });

--- a/src/renderers/link.ts
+++ b/src/renderers/link.ts
@@ -1,9 +1,9 @@
 import { MarkdownRenderer, RenderOptions } from '../rendering.types';
 import { MarkdownEntry } from '../shared.types';
 
-export type LinkEntry = {
+export interface LinkEntry extends MarkdownEntry {
   link: { source: string; text?: string; title?: string };
-} & MarkdownEntry;
+}
 
 export const linkRenderer: MarkdownRenderer = (
   entry: LinkEntry,

--- a/src/renderers/link.ts
+++ b/src/renderers/link.ts
@@ -1,16 +1,45 @@
 import { MarkdownRenderer, RenderOptions } from '../rendering.types';
 import { MarkdownEntry } from '../shared.types';
 
+/**
+ * A markdown entry for generating links.
+ */
 export interface LinkEntry extends MarkdownEntry {
-  link: { source: string; text?: string; title?: string };
+  /**
+   * The link settings and identifying property for the renderer.
+   */
+  link: {
+    /**
+     * The hypertext reference to the target resource.
+     */
+    href: string;
+
+    /**
+     * Hyperlink text to show for the link itself.
+     * When not provided, the href will be rendered as an auto-link.
+     * E.g., `<https://www.google.com>`
+     */
+    text?: string;
+
+    /**
+     * A title for the link. Ignored for links without text.
+     */
+    title?: string;
+  };
 }
 
+/**
+ * The renderer for link entries.
+ * @param entry The link entry.
+ * @param options Document-level render options.
+ * @returns Link markdown content.
+ */
 export const linkRenderer: MarkdownRenderer = (
   entry: LinkEntry,
   options: RenderOptions
 ) => {
   if ('link' in entry) {
-    const formattedLink = entry.link.source.replace(/\s/g, '%20');
+    const formattedLink = entry.link.href.replace(/\s/g, '%20');
 
     if (!entry.link.text) {
       return `<${formattedLink}>`;

--- a/src/renderers/link.ts
+++ b/src/renderers/link.ts
@@ -30,6 +30,7 @@ export interface LinkEntry extends MarkdownEntry {
 
 /**
  * The renderer for link entries.
+ *
  * @param entry The link entry.
  * @param options Document-level render options.
  * @returns Link markdown content.

--- a/src/renderers/ol.ts
+++ b/src/renderers/ol.ts
@@ -2,10 +2,10 @@ import { renderEntries, getMarkdownString } from '../rendering';
 import { MarkdownRenderer, RenderOptions } from '../rendering.types';
 import { ListItemEntry, MarkdownEntry } from '../shared.types';
 
-export type OrderedListEntry = {
+export interface OrderedListEntry extends MarkdownEntry {
   ol: ListItemEntry[];
   append?: string;
-} & MarkdownEntry;
+}
 
 export const olRenderer: MarkdownRenderer = (
   entry: OrderedListEntry,

--- a/src/renderers/ol.ts
+++ b/src/renderers/ol.ts
@@ -19,6 +19,7 @@ export interface OrderedListEntry extends MarkdownEntry {
 
 /**
  * The renderer for ordered list entries.
+ *
  * @param entry The ordererd list entry.
  * @param options Document-level render options.
  * @returns Block-level ordered list markdown content.

--- a/src/renderers/ol.ts
+++ b/src/renderers/ol.ts
@@ -2,11 +2,27 @@ import { renderEntries, getMarkdownString } from '../rendering';
 import { MarkdownRenderer, RenderOptions } from '../rendering.types';
 import { ListItemEntry, MarkdownEntry } from '../shared.types';
 
+/**
+ * A markdown entry for generating ordered lists.
+ */
 export interface OrderedListEntry extends MarkdownEntry {
+  /**
+   * The ordered list contetns and identifying property for the renderer.
+   */
   ol: ListItemEntry[];
+
+  /**
+   * Option which will arbitrarily append a string immediately below the ordered list, ignoring block-level settings.
+   */
   append?: string;
 }
 
+/**
+ * The renderer for ordered list entries.
+ * @param entry The ordererd list entry.
+ * @param options Document-level render options.
+ * @returns Block-level ordered list markdown content.
+ */
 export const olRenderer: MarkdownRenderer = (
   entry: OrderedListEntry,
   options: RenderOptions

--- a/src/renderers/p.ts
+++ b/src/renderers/p.ts
@@ -2,11 +2,27 @@ import { getMarkdownString } from '../rendering';
 import { MarkdownRenderer, RenderOptions } from '../rendering.types';
 import { InlineTypes, MarkdownEntry } from '../shared.types';
 
+/**
+ * A markdown entry for generating paragraphs.
+ */
 export interface ParagraphEntry extends MarkdownEntry {
+  /**
+   * The paragraph contents and identifying property for the renderer.
+   */
   p: InlineTypes;
+
+  /**
+   * Option which will arbitrarily append a string immediately below the paragraph, ignoring block-level settings.
+   */
   append?: string;
 }
 
+/**
+ * The renderer for paragraph entries.
+ * @param entry The paragraph entry.
+ * @param options Document-level render options.
+ * @returns Block-level paragraph markdown content.
+ */
 export const pRenderer: MarkdownRenderer = (
   entry: ParagraphEntry,
   options: RenderOptions

--- a/src/renderers/p.ts
+++ b/src/renderers/p.ts
@@ -2,10 +2,10 @@ import { getMarkdownString } from '../rendering';
 import { MarkdownRenderer, RenderOptions } from '../rendering.types';
 import { InlineTypes, MarkdownEntry } from '../shared.types';
 
-export type ParagraphEntry = {
+export interface ParagraphEntry extends MarkdownEntry {
   p: InlineTypes;
   append?: string;
-} & MarkdownEntry;
+}
 
 export const pRenderer: MarkdownRenderer = (
   entry: ParagraphEntry,

--- a/src/renderers/p.ts
+++ b/src/renderers/p.ts
@@ -19,6 +19,7 @@ export interface ParagraphEntry extends MarkdownEntry {
 
 /**
  * The renderer for paragraph entries.
+ *
  * @param entry The paragraph entry.
  * @param options Document-level render options.
  * @returns Block-level paragraph markdown content.

--- a/src/renderers/strikethrough.ts
+++ b/src/renderers/strikethrough.ts
@@ -2,10 +2,22 @@ import { getMarkdownString } from '../rendering';
 import { MarkdownRenderer, RenderOptions } from '../rendering.types';
 import { RichTextEntry, MarkdownEntry } from '../shared.types';
 
+/**
+ * A markdown entry for strikethrough text.
+ */
 export interface StrikethroughEntry extends MarkdownEntry, RichTextEntry {
+  /**
+   * The strikethrough text contents and identifying property for the renderer.
+   */
   strikethrough: RichTextEntry;
 }
 
+/**
+ * The renderer for strickethrough text entries.
+ * @param entry The strikethrough entry.
+ * @param options Document-level render options.
+ * @returns Strikethrough markdown content.
+ */
 export const strikethroughRenderer: MarkdownRenderer = (
   entry: StrikethroughEntry,
   options: RenderOptions

--- a/src/renderers/strikethrough.ts
+++ b/src/renderers/strikethrough.ts
@@ -2,10 +2,9 @@ import { getMarkdownString } from '../rendering';
 import { MarkdownRenderer, RenderOptions } from '../rendering.types';
 import { RichTextEntry, MarkdownEntry } from '../shared.types';
 
-export type StrikethroughEntry = {
+export interface StrikethroughEntry extends MarkdownEntry, RichTextEntry {
   strikethrough: RichTextEntry;
-} & MarkdownEntry &
-  RichTextEntry;
+}
 
 export const strikethroughRenderer: MarkdownRenderer = (
   entry: StrikethroughEntry,

--- a/src/renderers/strikethrough.ts
+++ b/src/renderers/strikethrough.ts
@@ -14,6 +14,7 @@ export interface StrikethroughEntry extends MarkdownEntry, RichTextEntry {
 
 /**
  * The renderer for strickethrough text entries.
+ *
  * @param entry The strikethrough entry.
  * @param options Document-level render options.
  * @returns Strikethrough markdown content.

--- a/src/renderers/string.ts
+++ b/src/renderers/string.ts
@@ -1,6 +1,15 @@
 import { MarkdownRenderer } from '../rendering.types';
 import { RichTextEntry } from '../shared.types';
 
+/**
+ * A markdown entry for generating a plain string.
+ * This is the most fundamental entry type.
+ */
 export interface String extends RichTextEntry {}
 
+/**
+ * The renderer for string entries.
+ * @param entry A string of text.
+ * @returns String content.
+ */
 export const stringRenderer: MarkdownRenderer = (entry: string) => entry;

--- a/src/renderers/string.ts
+++ b/src/renderers/string.ts
@@ -9,6 +9,7 @@ export interface String extends RichTextEntry {}
 
 /**
  * The renderer for string entries.
+ *
  * @param entry A string of text.
  * @returns String content.
  */

--- a/src/renderers/sub.ts
+++ b/src/renderers/sub.ts
@@ -2,11 +2,10 @@ import { getMarkdownString } from '../rendering';
 import { MarkdownRenderer, RenderOptions } from '../rendering.types';
 import { RichTextEntry, MarkdownEntry } from '../shared.types';
 
-export type SubscriptEntry = {
+export interface SubscriptEntry extends MarkdownEntry, RichTextEntry {
   sub: RichTextEntry;
   html?: boolean;
-} & MarkdownEntry &
-  RichTextEntry;
+}
 
 export const subRenderer: MarkdownRenderer = (
   entry: SubscriptEntry,

--- a/src/renderers/sub.ts
+++ b/src/renderers/sub.ts
@@ -20,6 +20,7 @@ export interface SubscriptEntry extends MarkdownEntry, RichTextEntry {
 
 /**
  * The renderer for subscript entries.
+ *
  * @param entry The subscript entry.
  * @param options Document-level render options.
  * @returns Subscript markdown content.

--- a/src/renderers/sub.ts
+++ b/src/renderers/sub.ts
@@ -2,11 +2,28 @@ import { getMarkdownString } from '../rendering';
 import { MarkdownRenderer, RenderOptions } from '../rendering.types';
 import { RichTextEntry, MarkdownEntry } from '../shared.types';
 
+/**
+ * A markdown entry for generating subscript text.
+ */
 export interface SubscriptEntry extends MarkdownEntry, RichTextEntry {
+  /**
+   * The subscript contents and identifying property for the renderer.
+   */
   sub: RichTextEntry;
+
+  /**
+   * Option to render the subscript indicators as HTML.
+   * Default: false
+   */
   html?: boolean;
 }
 
+/**
+ * The renderer for subscript entries.
+ * @param entry The subscript entry.
+ * @param options Document-level render options.
+ * @returns Subscript markdown content.
+ */
 export const subRenderer: MarkdownRenderer = (
   entry: SubscriptEntry,
   options: RenderOptions

--- a/src/renderers/sup.ts
+++ b/src/renderers/sup.ts
@@ -2,11 +2,28 @@ import { getMarkdownString } from '../rendering';
 import { MarkdownRenderer, RenderOptions } from '../rendering.types';
 import { RichTextEntry, MarkdownEntry } from '../shared.types';
 
+/**
+ * A markdown entry for generating superscript text.
+ */
 export interface SuperscriptEntry extends MarkdownEntry, RichTextEntry {
+  /**
+   * The superscript contents and identifying property for the renderer.
+   */
   sup: RichTextEntry;
+
+  /**
+   * Option to render the superscript indicators as HTML.
+   * Default: false
+   */
   html?: boolean;
 }
 
+/**
+ * The renderer for superscript entries.
+ * @param entry The superscript entry.
+ * @param options Document-level render options.
+ * @returns Superscript markdown content.
+ */
 export const supRenderer: MarkdownRenderer = (
   entry: SuperscriptEntry,
   options: RenderOptions

--- a/src/renderers/sup.ts
+++ b/src/renderers/sup.ts
@@ -20,6 +20,7 @@ export interface SuperscriptEntry extends MarkdownEntry, RichTextEntry {
 
 /**
  * The renderer for superscript entries.
+ *
  * @param entry The superscript entry.
  * @param options Document-level render options.
  * @returns Superscript markdown content.

--- a/src/renderers/sup.ts
+++ b/src/renderers/sup.ts
@@ -2,11 +2,10 @@ import { getMarkdownString } from '../rendering';
 import { MarkdownRenderer, RenderOptions } from '../rendering.types';
 import { RichTextEntry, MarkdownEntry } from '../shared.types';
 
-export type SuperscriptEntry = {
+export interface SuperscriptEntry extends MarkdownEntry, RichTextEntry {
   sup: RichTextEntry;
   html?: boolean;
-} & MarkdownEntry &
-  RichTextEntry;
+}
 
 export const supRenderer: MarkdownRenderer = (
   entry: SuperscriptEntry,

--- a/src/renderers/table.test.ts
+++ b/src/renderers/table.test.ts
@@ -249,7 +249,7 @@ describe('given a table entry', () => {
               text: [
                 { bold: 'Hello, please go to' },
                 ' ',
-                { link: { text: 'Google', source: 'https://www.google.com' } },
+                { link: { text: 'Google', href: 'https://www.google.com' } },
                 '.',
               ],
             },
@@ -261,7 +261,7 @@ describe('given a table entry', () => {
                 {
                   img: {
                     alt: 'Placeholder!',
-                    href: 'https://via.placeholder.com/150',
+                    source: 'https://via.placeholder.com/150',
                   },
                 },
               ],

--- a/src/renderers/table.ts
+++ b/src/renderers/table.ts
@@ -3,13 +3,13 @@ import { MarkdownRenderer, RenderOptions } from '../rendering.types';
 import { MarkdownEntry } from '../shared.types';
 import { TextEntry } from './text';
 
-export type TableEntry = {
+export interface TableEntry extends MarkdownEntry {
   table: {
     columns: (TableColumn | string)[];
     rows: (TableRow | (TextEntry | string)[])[];
   };
   append?: string;
-} & MarkdownEntry;
+}
 
 export type TableColumn = {
   name: string;

--- a/src/renderers/table.ts
+++ b/src/renderers/table.ts
@@ -3,23 +3,63 @@ import { MarkdownRenderer, RenderOptions } from '../rendering.types';
 import { MarkdownEntry } from '../shared.types';
 import { TextEntry } from './text';
 
+/**
+ * A markdown entry for generating tables.
+ */
 export interface TableEntry extends MarkdownEntry {
+  /**
+   * The table row and column data, and identifying property for the renderer.
+   */
   table: {
+    /**
+     * The column headers for the table.
+     */
     columns: (TableColumn | string)[];
+
+    /**
+     * The row data for the table.
+     */
     rows: (TableRow | (TextEntry | string)[])[];
   };
+
+  /**
+   * Option which will arbitrarily append a string immediately below the table, ignoring block-level settings.
+   */
   append?: string;
 }
 
+/**
+ * A table column header.
+ */
 export type TableColumn = {
+  /**
+   * The name of the column.
+   */
   name: string;
+
+  /**
+   * The horizontal alignment of the entire column.
+   */
   align?: 'left' | 'center' | 'right';
 };
 
+/**
+ * A a row of table data.
+ */
 export type TableRow = {
+  /**
+   * A cell of table data.
+   * Each key in this object represents a column header name, case-sensitively.
+   */
   [key: string]: string | TextEntry;
 };
 
+/**
+ * The renderer for table entries.
+ * @param entry The table entry.
+ * @param options Document-level render options.
+ * @returns Block-level table markdown content.
+ */
 export const tableRenderer: MarkdownRenderer = (
   entry: TableEntry,
   options: RenderOptions

--- a/src/renderers/table.ts
+++ b/src/renderers/table.ts
@@ -56,6 +56,7 @@ export type TableRow = {
 
 /**
  * The renderer for table entries.
+ *
  * @param entry The table entry.
  * @param options Document-level render options.
  * @returns Block-level table markdown content.

--- a/src/renderers/tasks.ts
+++ b/src/renderers/tasks.ts
@@ -2,16 +2,43 @@ import { getMarkdownString } from '../rendering';
 import { MarkdownRenderer, RenderOptions } from '../rendering.types';
 import { InlineTypes, MarkdownEntry } from '../shared.types';
 
+/**
+ * A markdown entry for generating task lists.
+ */
 export interface TaskListEntry extends MarkdownEntry {
+  /**
+   * The task list entries and identifying property for the renderer.
+   */
   tasks: (InlineTypes | TaskEntry)[];
+
+  /**
+   * Option which will arbitrarily append a string immediately below the task list, ignoring block-level settings.
+   */
   append?: string;
 }
 
+/**
+ * A task in the task list.
+ */
 export type TaskEntry = {
+  /**
+   * Inline content for the current task.
+   */
   task: InlineTypes;
+
+  /**
+   * Indicator of whether the task has been completed or not.
+   * Default: false
+   */
   completed?: boolean;
 };
 
+/**
+ * The renderer for task list entries.
+ * @param entry The task list entry.
+ * @param options Document-level render options.
+ * @returns Block-level task list markdown content.
+ */
 export const tasksRenderer: MarkdownRenderer = (
   entry: TaskListEntry,
   options: RenderOptions

--- a/src/renderers/tasks.ts
+++ b/src/renderers/tasks.ts
@@ -35,6 +35,7 @@ export type TaskEntry = {
 
 /**
  * The renderer for task list entries.
+ *
  * @param entry The task list entry.
  * @param options Document-level render options.
  * @returns Block-level task list markdown content.

--- a/src/renderers/tasks.ts
+++ b/src/renderers/tasks.ts
@@ -2,10 +2,10 @@ import { getMarkdownString } from '../rendering';
 import { MarkdownRenderer, RenderOptions } from '../rendering.types';
 import { InlineTypes, MarkdownEntry } from '../shared.types';
 
-export type TaskListEntry = {
+export interface TaskListEntry extends MarkdownEntry {
   tasks: (InlineTypes | TaskEntry)[];
   append?: string;
-} & MarkdownEntry;
+}
 
 export type TaskEntry = {
   task: InlineTypes;

--- a/src/renderers/text.ts
+++ b/src/renderers/text.ts
@@ -5,9 +5,9 @@ import { CodeEntry } from './code';
 import { ImageEntry } from './img';
 import { LinkEntry } from './link';
 
-export type TextEntry = {
+export interface TextEntry extends InlineTypes {
   text: string | (RichTextEntry | LinkEntry | ImageEntry | CodeEntry)[];
-} & InlineTypes;
+}
 
 export const textRenderer: MarkdownRenderer = (
   entry: TextEntry,

--- a/src/renderers/text.ts
+++ b/src/renderers/text.ts
@@ -5,10 +5,23 @@ import { CodeEntry } from './code';
 import { ImageEntry } from './img';
 import { LinkEntry } from './link';
 
+/**
+ * A markdown entry for generating inline text.
+ * Used for injecting rich inline text in most places, such as a paragraph or a table cell.
+ */
 export interface TextEntry extends InlineTypes {
+  /**
+   * The inline text contents and identifying property for the renderer.
+   */
   text: string | (RichTextEntry | LinkEntry | ImageEntry | CodeEntry)[];
 }
 
+/**
+ * The renderer for inline text entries.
+ * @param entry The text entry.
+ * @param options Document-level render options.
+ * @returns Inline text markdown content.
+ */
 export const textRenderer: MarkdownRenderer = (
   entry: TextEntry,
   options: RenderOptions

--- a/src/renderers/text.ts
+++ b/src/renderers/text.ts
@@ -18,6 +18,7 @@ export interface TextEntry extends InlineTypes {
 
 /**
  * The renderer for inline text entries.
+ *
  * @param entry The text entry.
  * @param options Document-level render options.
  * @returns Inline text markdown content.

--- a/src/renderers/ul.ts
+++ b/src/renderers/ul.ts
@@ -2,14 +2,38 @@ import { renderEntries, getMarkdownString } from '../rendering';
 import { MarkdownRenderer, RenderOptions } from '../rendering.types';
 import { ListItemEntry, MarkdownEntry } from '../shared.types';
 
+/**
+ * A markdown entry for generating unordered lists.
+ */
 export interface UnorderedListEntry extends MarkdownEntry {
+  /**
+   * The unordered list contents and identifying property for the renderer.
+   */
   ul: ListItemEntry[];
+
+  /**
+   * An indicator specifying which character to use when denoting a list item.
+   * Default: '-'
+   */
   indicator?: UnorderedListItemIndicator;
+
+  /**
+   * Option which will arbitrarily append a string immediately below the unordered list, ignoring block-level settings.
+   */
   append?: string;
 }
 
+/**
+ * Eligible characters for denoting a list item.
+ */
 export type UnorderedListItemIndicator = '-' | '*' | '+';
 
+/**
+ * The renderer for unordered list entries.
+ * @param entry The unordered list entry.
+ * @param options Document-level render options.
+ * @returns Block-level unordered list markdown content.
+ */
 export const ulRenderer: MarkdownRenderer = (
   entry: UnorderedListEntry,
   options: RenderOptions

--- a/src/renderers/ul.ts
+++ b/src/renderers/ul.ts
@@ -2,11 +2,11 @@ import { renderEntries, getMarkdownString } from '../rendering';
 import { MarkdownRenderer, RenderOptions } from '../rendering.types';
 import { ListItemEntry, MarkdownEntry } from '../shared.types';
 
-export type UnorderedListEntry = {
+export interface UnorderedListEntry extends MarkdownEntry {
   ul: ListItemEntry[];
   indicator?: UnorderedListItemIndicator;
   append?: string;
-} & MarkdownEntry;
+}
 
 export type UnorderedListItemIndicator = '-' | '*' | '+';
 

--- a/src/renderers/ul.ts
+++ b/src/renderers/ul.ts
@@ -30,6 +30,7 @@ export type UnorderedListItemIndicator = '-' | '*' | '+';
 
 /**
  * The renderer for unordered list entries.
+ *
  * @param entry The unordered list entry.
  * @param options Document-level render options.
  * @returns Block-level unordered list markdown content.

--- a/src/rendering.test.ts
+++ b/src/rendering.test.ts
@@ -138,7 +138,7 @@ Testing`
                 text: [
                   {
                     link: {
-                      source: 'https://www.google.com',
+                      href: 'https://www.google.com',
                       text: 'Time to get back to testing',
                       title:
                         "Don't worry, search engines are a vital part of development",
@@ -147,7 +147,7 @@ Testing`
                   ' ',
                   {
                     img: {
-                      href: 'https://via.placeholder.com/25',
+                      source: 'https://via.placeholder.com/25',
                       alt: 'A 25x25 placeholder image',
                       title: 'Here is a handy placeholder image',
                     },

--- a/src/rendering.ts
+++ b/src/rendering.ts
@@ -41,6 +41,7 @@ export function tsMarkdown(data: MarkdownEntry[], options?: RenderOptions) {
 
 /**
  * Finds and corrects and mid-word bold/italics that use hyphens, changing the hyphens to asterisks, per best practice: https://www.markdownguide.org/basic-syntax/#bold-best-practices
+ *
  * @param document the rendered document
  * @returns document with mid-world bold and italics set to asterisks
  */

--- a/src/rendering.ts
+++ b/src/rendering.ts
@@ -7,6 +7,13 @@ import {
 } from './rendering.types';
 import { MarkdownEntry } from './shared.types';
 
+/**
+ * The main entrypoint into rendering documents in **ts-markdown**.
+ *
+ * @param data The markdown entries which should be rendered into a markdown document.
+ * @param options Document-level options which can affect broad aspects of the rendering process.
+ * @returns A string of markdown.
+ */
 export function tsMarkdown(data: MarkdownEntry[], options?: RenderOptions) {
   options ??= {
     prefix: '',
@@ -16,18 +23,14 @@ export function tsMarkdown(data: MarkdownEntry[], options?: RenderOptions) {
 
   let document = renderEntries(data, options);
 
-  document = options.applyCompletedDocumentChangesPreFootnotes
-    ? options.applyCompletedDocumentChangesPreFootnotes(data, document, options)
+  document = options.onDocumentFootnoteAppending
+    ? options.onDocumentFootnoteAppending(data, document, options)
     : document;
 
   document = appendFootnotes(data, document, options);
 
-  document = options.applyCompletedDocumentChangesPostFootnotes
-    ? options.applyCompletedDocumentChangesPostFootnotes(
-        data,
-        document,
-        options
-      )
+  document = options.onDocumentFootnoteAppended
+    ? options.onDocumentFootnoteAppended(data, document, options)
     : document;
 
   // TODO: Formalize a post-render callback option
@@ -57,7 +60,17 @@ function correctInvalidMidWordBoldAndItalics(document: string): string {
     );
 }
 
-export function renderEntries(data: MarkdownEntry[], options: RenderOptions) {
+/**
+ * Reduces an array of markdown entries to a single string.
+ *
+ * @param data the markdown entries to process.
+ * @param options Document-level options which can affect broad aspects of the rendering process.
+ * @returns a string of markdown content.
+ */
+export function renderEntries(
+  data: MarkdownEntry[],
+  options: RenderOptions
+): string {
   let prefix = options.prefix ?? '';
 
   let textStack = '';
@@ -104,6 +117,13 @@ function isAppendable(entry: MarkdownEntry) {
   );
 }
 
+/**
+ * Reduces a single markdown entry to a string of markdown content.
+ *
+ * @param entry the target markdown entry or string of text.
+ * @param options Document-level options which can affect broad aspects of the rendering process.
+ * @returns
+ */
 export function getMarkdownString(
   entry: MarkdownEntry | string,
   options: RenderOptions

--- a/src/rendering.types.ts
+++ b/src/rendering.types.ts
@@ -1,16 +1,17 @@
 import { UnorderedListItemIndicator } from './renderers/ul';
 import { MarkdownEntry } from './shared.types';
 
-export type RenderPrefixFunction = (
-  index: number,
-  entry?: MarkdownEntry
-) => string;
+export interface RenderPrefixFunction {
+  (index: number, entry?: MarkdownEntry): string;
+}
 
 export type MarkdownRenderPrefix = string | RenderPrefixFunction;
 
-export type Renderers = { [key: string]: MarkdownRenderer };
+export interface Renderers {
+  [key: string]: MarkdownRenderer;
+}
 
-export type RenderOptions = {
+export interface RenderOptions {
   unorderedListItemIndicator?: UnorderedListItemIndicator;
   useH1Underlining?: boolean;
   useH2Underlining?: boolean;
@@ -37,13 +38,12 @@ export type RenderOptions = {
   useCodeblockFencing?: boolean | '`' | '~';
   boldIndicator?: '*' | '_';
   italicIndicator?: '*' | '_';
-};
+}
 
 // TODO: Figure out how to require that `entry` extend `MarkdownEntry` and be containable in the `Renderers` type.
-export type MarkdownRenderer = (
-  entry: any,
-  options: RenderOptions
-) => MarkdownRenderResult;
+export interface MarkdownRenderer {
+  (entry: any, options: RenderOptions): MarkdownRenderResult;
+}
 
 export type MarkdownRenderResult =
   | string

--- a/src/rendering.types.ts
+++ b/src/rendering.types.ts
@@ -1,23 +1,73 @@
 import { UnorderedListItemIndicator } from './renderers/ul';
 import { MarkdownEntry } from './shared.types';
 
+/**
+ * A function providing prefix text to the markdown rendering code.
+ * Provides some context for where in an array of items it is, as well as which markdown entry is it working with.
+ * Often used when differentiating between parent and nested child content, such as with adding block elements to a list item.
+ */
 export interface RenderPrefixFunction {
   (index: number, entry?: MarkdownEntry): string;
 }
 
+/**
+ * A prefix to use when rendering a line of markdown.
+ * Allows for recursive, nested markdown rendering.
+ */
 export type MarkdownRenderPrefix = string | RenderPrefixFunction;
 
+/**
+ * A key/value object map of renderers where
+ * - key: an identifying property name to look for when processing markdown entries.
+ * - value: a renderer to use when encountering a markdown entries that has a key matching this value's key.
+ */
 export interface Renderers {
   [key: string]: MarkdownRenderer;
 }
 
+/**
+ * Document-level options which can affect broad aspects of the rendering process.
+ * Whenever these options have entry-level equivalent options, the entry-level options take precedence.
+ */
 export interface RenderOptions {
+  /**
+   * An indicator specifying which character to use when denoting an unordered list item.
+   * Default: '-'
+   */
   unorderedListItemIndicator?: UnorderedListItemIndicator;
+
+  /**
+   * Option which will use '=' underlining for denoting an h1 rather than a '#' prefix.
+   */
   useH1Underlining?: boolean;
+
+  /**
+   * Option which will use '-' underlining for denoting an h2 rather than a '##' prefix.
+   */
   useH2Underlining?: boolean;
+
+  /**
+   * Option to render subscript indicators as HTML.
+   * Default: false
+   */
   useSubscriptHtml?: boolean;
+
+  /**
+   * Option to render superscript indicators as HTML.
+   * Default: false
+   */
   useSuperscriptHtml?: boolean;
+
+  /**
+   * Option to render description lists as HTML.
+   * Default: false
+   */
   useDescriptionListHtml?: boolean;
+
+  /**
+   * An arbitrary prefix which will be prepended to every line of text generated within the context of these options.
+   * Typically used by the main markdown generator when recursively rendering lines of markdown.
+   */
   prefix?: MarkdownRenderPrefix;
 
   /**
@@ -25,26 +75,81 @@ export interface RenderOptions {
    */
   renderers?: Renderers;
 
-  applyCompletedDocumentChangesPreFootnotes?: (
+  /**
+   * A hook for injecting or manipulating document content before footnotes are added to the end of the document.
+   * Expects the caller to return the document with any changes applied to it.
+   */
+  onDocumentFootnoteAppending?: (
+    /**
+     * The originally-submitted markdown entries.
+     */
     data: MarkdownEntry[],
+
+    /**
+     * The document after initial rendering but before footnotes are applied.
+     */
     document: string,
+
+    /**
+     * The originally-submitted document-level options.
+     */
     options: RenderOptions
   ) => string;
-  applyCompletedDocumentChangesPostFootnotes?: (
+
+  /**
+   * A hook for injecting or manipulating document content after footnotes are added to the end of the document.
+   * Expects the caller to return the document with any changes applied to it.
+   */
+  onDocumentFootnoteAppended?: (
+    /**
+     * The originally-submitted markdown entries.
+     */
     data: MarkdownEntry[],
+
+    /**
+     * The document after initial rendering and after footnotes are applied.
+     */
     document: string,
+
+    /**
+     * The originally-submitted document-level options.
+     */
     options: RenderOptions
   ) => string;
+
+  /**
+   * Indicates whether or not to use codeblock fencing rather than standard indentation for codeblocks.
+   * Supplying `true` tells the renderer to always use code fencing with the default character.
+   * Otherwise, supplying a character tells the renderer to always use code fencing with the specified character.
+   * Omitting this options results in indented codeblocks.
+   */
   useCodeblockFencing?: boolean | '`' | '~';
+
+  /**
+   * The character which will be used to signify bolded text.
+   */
   boldIndicator?: '*' | '_';
+
+  /**
+   * Indicator determining what character is used to denote italics.
+   */
   italicIndicator?: '*' | '_';
 }
 
 // TODO: Figure out how to require that `entry` extend `MarkdownEntry` and be containable in the `Renderers` type.
+/**
+ * A function which can take an entry and render markdown.
+ * This function is designed to receive a markdown entry that it is able to render, provided the collection of renderers has the correct key associated with this renderer.
+ */
 export interface MarkdownRenderer {
   (entry: any, options: RenderOptions): MarkdownRenderResult;
 }
 
+/**
+ * The result of rendering a markdown entry.
+ * Can be a string or a more specific set of markdown content which requires metadata, such as being block-level.
+ * The additional metadata tells the markdown generator how to handle assembling this markdown in relation to other entries.
+ */
 export type MarkdownRenderResult =
   | string
   | { markdown: string; blockLevel: true };

--- a/src/shared.types.ts
+++ b/src/shared.types.ts
@@ -3,8 +3,17 @@
  */
 export interface MarkdownEntry {}
 
+/**
+ * A marker interface that represents inline text that has been manipulated visually to provide more expressive text.
+ */
 export interface RichTextEntry extends InlineTypes {}
 
+/**
+ * A marker interface that represents any text that can be rendered together on a single line.
+ */
 export interface InlineTypes {}
 
+/**
+ * Valid list item content, to be used in an ordered or unordered list.
+ */
 export type ListItemEntry = MarkdownEntry | MarkdownEntry[];


### PR DESCRIPTION
Added JSDoc comments to document all exported content.

Breaking changes:
- Changed the `ImageEntry` field `img.href` to `img.source`.
- Changed the `LinkEntry` field `link.source` to `link.href`.

Applied minor adjustment to the readme.