### PR TITLE
Trimmed Readme and Refreshed TypeDocs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,20 +2,13 @@
 
 An extensible TypeScript markdown generator that takes JSON and creates a markdown document.
 
-- [Getting Started](#getting-started)
-- [Usage](#usage)
-  - [Example - Generating a Simple Document](#example---generating-a-simple-document)
-  - [Example - Using Markdown Helper Functions](#example---using-markdown-helper-functions)
-- [Options](#options)
-  - [Document-level Options](#document-level-options)
-  - [Entry-level Options](#entry-level-options)
-  - [Option Precedence: Entry-level > Document-level > Defaults](#option-precedence-entry-level--document-level--defaults)
-  - [More About Options](#more-about-options)
-- [Extending ts-markdown](#extending-ts-markdown)
-  - [A Simple Extension](#a-simple-extension)
-  - [More Involved Extension Example](#more-involved-extension-example)
-  - [Overriding an Existing Renderer](#overriding-an-existing-renderer)
-  - [Remarks on Extensibility](#remarks-on-extensibility)
+[**View the Docs**](https://kgar.github.io/ts-markdown/)
+
+---
+
+- [Quick Start](#quick-start)
+- [Extensibility](#extensibility)
+- [Compatibility](#compatibility)
 - [Why This Project?](#why-this-project)
 - [🙌 Credit](#-credit)
   - [Credit to json2md](#credit-to-json2md)
@@ -23,34 +16,27 @@ An extensible TypeScript markdown generator that takes JSON and creates a markdo
 - [🌏 Contribution Guidelines](#-contribution-guidelines)
 - [License](#license)
 
-## Getting Started
+## Quick Start
 
-To use **ts-markdown** in your project, run:
+Install **ts-markdown**:
 
 ```sh
 npm install ts-markdown
 # or "yarn add ts-markdown"
 ```
 
-## Usage
-
-**ts-markdown** is written in TypeScript. It works with node JS v16.x and higher. Earlier versions may also work, but it is not guaranteed.
-
-**ts-markdown** revolves around sending an array of "markdown entry" objects to the `tsMarkdown()` function.
-
-### Example - Generating a Simple Document
-
-Given this code:
+Generate some markdown:
 
 ```ts
 import { tsMarkdown } from 'ts-markdown';
 
-tsMarkdown([
+// Make markdown entries
+const entries = [
   {
     h4: 'Hello, world!',
   },
   {
-    blockquote: "Let's generate some markdown!",
+    blockquote: "Let's generate markdown!",
   },
   { p: 'Generating markdown from data can be simple. All you need are:' },
   {
@@ -62,7 +48,9 @@ tsMarkdown([
       },
     ],
   },
-]);
+];
+
+return tsMarkdown(entries); // returns the markdown document as a string
 ```
 
 And the result is:
@@ -70,7 +58,7 @@ And the result is:
 ```md
 #### Hello, world!
 
-> Let's generate some markdown!
+> Let's generate markdown!
 
 Generating markdown from data can be simple. All you need are:
 
@@ -79,361 +67,19 @@ Generating markdown from data can be simple. All you need are:
 3. and a place to run :checkered_flag:
 ```
 
-### Example - Using Markdown Helper Functions
+For more information about supported markdown elements, view the [type docs](https://kgar.github.io/ts-markdown/modules.html). All support markdown elements end with `Entry`, such as `LinkEntry`, `ImageEntry`, `UnorderedListEntry`, and so on.
 
-The same document from the previous example can be generated using **markdown helper functions**:
+For more examples of **generating markdown**, check out the [cookbook](https://kgar.github.io/ts-markdown/pages/cookbook.html).
 
-```ts
-import { blockquote, emoji, h4, ol, p, text, tsMarkdown } from 'ts-markdown';
+## Extensibility
 
-tsMarkdown([
-  h4('Hello, world!'),
-  blockquote("Let's generate some markdown!"),
-  p('Generating markdown from data can be simple. All you need are:'),
-  ol([
-    'objects',
-    'a function',
-    text(['and a place to run ', emoji('checkered_flag')]),
-  ]),
-]);
-```
+You can extend **ts-markdown** to render your own custom elements or even override existing renderers.
 
-## Options
+For more information on extending **ts-markdown**, see [Extending ts-markdown](https://kgar.github.io/ts-markdown/pages/extending-ts-markdown.html).
 
-**ts-markdown** has the following types of options:
+## Compatibility
 
-- **document-level**: options that apply to the entire document
-- **entry-level**: options that apply to a specific type of `MarkdownEntry`
-
-### Document-level Options
-
-Document-level options affect either a single entry type, a particular lifecycle event in document rendering, or some overarching aspect. Entry-specific options at the document-level are a convenient shortcut for applying your desired style to document rendering, reducing unnecessary props on your individual objects.
-
-You can specify options at the document-level by passing in a `RenderOptions` object when calling the `tsMarkdown()` function:
-
-```ts
-const options: RenderOptions = {
-  useH1Underlining: true,
-};
-
-tsMarkdown(myEntries, options);
-// 👆 H1 markdown will now have underlining whenever these options are passed into `tsMarkdown()`
-```
-
-> **Note**: We Have Defaults
->
-> Any options that you do not specify fall back to a default value, so you do not have to specify all options. You can pick and choose the ones you want to specify.
-
-### Entry-level Options
-
-Some markdown entries have their own entry-level options.
-
-For example, unordered lists have an option for which indicator to use:
-
-```ts
-const ulEntry: UnorderedListEntry = {
-  ul: ['Hello, world!', 'Goodbye, Moon Man!'],
-  indicator: '+',
-};
-
-tsMarkdown([ulEntry]);
-```
-
-The result is a list with items indicated by `+`:
-
-```
-+ Hello, world!
-+ Goodbye, Moon Man!
-```
-
-### Option Precedence: Entry-level > Document-level > Defaults
-
-> Entry-level settings, if specified, take precedence over all else.
->
-> Then, document-level settings are considered.
->
-> Otherwise, we use defaults.
-
-When specifying options, you may need to provide entry- and document-level options which conflict with each other.
-
-For example, I want all bolded text to use underscores `_`, except I want one entry to use asterisks `*`:
-
-```ts
-import { tsMarkdown } from './rendering';
-import { RenderOptions } from './rendering.types';
-import { MarkdownEntry } from './shared.types';
-
-const entry: MarkdownEntry = {
-  text: [
-    { bold: 'Note' },
-    ' - This ',
-    { bold: 'is' },
-    ' a ',
-    {
-      bold: 'sample',
-      // 👇 this is an entry-level option
-      indicator: '*',
-    },
-  ],
-};
-
-// 👇 these are document-level options
-const options: RenderOptions = {
-  boldIndicator: '_',
-};
-
-tsMarkdown([entry], options);
-```
-
-The rendered markdown is:
-
-```
-__Note__ - This __is__ a **sample**
-```
-
-### More About Options
-
-> API documentation is in the works. In the meantime, you can view the types for any of the markdown entries by visiting:
->
-> - [rendering.types.ts](https://github.com/kgar/ts-markdown/blob/main/src/rendering.types.ts)
-> - Any renderer ts file, such as [bold.ts](https://github.com/kgar/ts-markdown/blob/main/src/renderers/bold.ts)
-
-## Extending ts-markdown
-
-You can add your own custom markdown renderers into the mix.
-
-### A Simple Extension
-
-Let's make an extension which wraps around some text like `OHAI ${textHere}!`.
-
-First, let's make a custom render extension using a super-compact approach:
-
-```ts
-import { getRenderers } from './defaults';
-import { tsMarkdown } from './rendering';
-
-let entry = {
-  sayHelloTo: 'friend',
-};
-
-tsMarkdown([entry], {
-  renderers: getRenderers({
-    sayHelloTo: (entry: { sayHelloTo: string }) => {
-      return `OHAI ${entry.sayHelloTo}!`;
-    },
-  }),
-});
-```
-
-We get:
-
-```
-OHAI friend!
-```
-
-Here's a longer form where we declare types and assign more variables along the way:
-
-```ts
-import { getRenderers } from './defaults';
-import { tsMarkdown } from './rendering';
-import { MarkdownRenderer } from './rendering.types';
-
-type SayHelloToEntry = {
-  sayHelloTo: string;
-};
-
-const sayHelloToRenderer: MarkdownRenderer = (
-  entry: SayHelloToEntry,
-  options
-) => {
-  return `OHAI ${entry.sayHelloTo}!`;
-};
-
-const myCustomRenderers = { sayHelloTo: sayHelloToRenderer };
-
-const renderers = getRenderers(myCustomRenderers);
-
-let entry: SayHelloToEntry = {
-  sayHelloTo: 'friend',
-};
-
-tsMarkdown([entry], { renderers });
-```
-
-Let's break down the longer form:
-
-```ts
-import { getRenderers } from './defaults';
-import { tsMarkdown } from './rendering';
-import { MarkdownRenderer } from './rendering.types';
-
-// ✅ Declare a type for your entry.
-// The naming convention is to suffix your element name with "Entry", so:
-type SayHelloToEntry = {
-  sayHelloTo: string;
-  // 👆 This is the identifying property.
-  // All markdown entries have it.
-  // Unordered lists are identified with `ul`:
-  // { ul: myListItems }
-  //   👆
-  // When looking for a renderer, we will try to find it based on properties on the entry object 🤞
-};
-
-// ✅ Make a renderer of type `MarkdownRenderer` and return a string, whatever that string is.
-const sayHelloToRenderer: MarkdownRenderer = (
-  entry: SayHelloToEntry,
-  options
-  // 👆 Sometimes, you need access to the document-level options. Here they are!
-) => {
-  return `OHAI ${entry.sayHelloTo}!`;
-};
-
-// ✅ Create an object with all of your custom renderers to be used when creating markdown:
-const myCustomRenderers = { sayHelloTo: sayHelloToRenderer };
-
-// ✅ Get the standard set of renderers and add your custom renderers:
-const renderers = getRenderers(myCustomRenderers);
-
-// ✅ Make some data and generate some markdown!
-let entry: SayHelloToEntry = {
-  sayHelloTo: 'friend',
-};
-
-tsMarkdown([entry], { renderers });
-```
-
-### More Involved Extension Example
-
-Here's an example in TypeScript of adding an [Obsidian.md](https://obsidian.md/) [callout](https://help.obsidian.md/How+to/Use+callouts) renderer, which is truly the fanciest of blockquotes:
-
-```ts
-import {
-  MarkdownEntry,
-  MarkdownRenderer,
-  RenderOptions,
-  BlockquoteEntry,
-  renderEntries,
-  getRenderers,
-  tsMarkdown,
-} from 'ts-markdown';
-
-// Declare a type for your entry.
-type ObsidianCalloutEntry = {
-  callout: {
-    type: string;
-    title?: string;
-    content: MarkdownEntry | MarkdownEntry[];
-  };
-};
-
-// Create a MarkdownRenderer.
-const calloutRenderer: MarkdownRenderer = (
-  entry: ObsidianCalloutEntry,
-  options: RenderOptions
-) => {
-  let titleText = entry.callout.title ? ` ${entry.callout.title}` : '';
-
-  let content = Array.isArray(entry.callout.content)
-    ? entry.callout.content
-    : [entry.callout.content];
-
-  const blockquote: BlockquoteEntry = {
-    blockquote: [{ p: `[!${entry.callout.type}]${titleText}` }, ...content],
-  };
-
-  // For markdown elements that are block-level,
-  // 🚫 don't return just a string
-  // ✅ use the object return type as seen here.
-  return {
-    markdown: renderEntries([blockquote], options),
-    // This tells the markdown renderer to ensure
-    // there are 2 newlines between this element
-    // and other elements.
-    blockLevel: true,
-  };
-};
-
-// Using your custom callout
-const callout: ObsidianCalloutEntry = {
-  callout: {
-    type: 'tip',
-    title: 'Welcome, Friends',
-    content: [
-      {
-        h2: 'Content Creation',
-      },
-      {
-        p: 'Obsidian allows you to create content quickly and easily, while rendering a view of your content that is satisfying to behold.',
-      },
-    ],
-  },
-};
-
-// ts-markdown options are optional 😉
-const options = {
-  // Get the default renderers and pass in your own custom renderers
-  // with a key that matches the uniquely identifying property
-  // of your custom markdown entry.
-  renderers: getRenderers({ callout: calloutRenderer }),
-};
-
-tsMarkdown([callout], options);
-```
-
-This will render the following markdown:
-
-```md
-> [!tip] Welcome, Friends
->
-> ## Content Creation
->
-> Obsidian allows you to create content quickly and easily, while rendering a view of your content that is satisfying to behold.
-```
-
-How the callout is rendered in Obsidian:
-
-![](https://github.com/kgar/data-driven-markdown/blob/main/images/obsidian-callout-example.jpg)
-
-> **Note**: We reused existing renderers! :exploding_head:
->
-> In the above example, we were able to use the existing blockquote markdown renderer and add some extra functionality to it.
->
-> We gave it a new name and its own uniquely identifying property ("callout"), so it didn't override the existing blockquote renderer, so we're able to use both.
-
-### Overriding an Existing Renderer
-
-You can also completely override an existing renderer. For example, let's have bolded text wrapped in turtles 🐢:
-
-```ts
-import { getRenderers } from './defaults';
-import { tsMarkdown } from './rendering';
-
-let entry = {
-  bold: 'I can be a professional turtle if I want.',
-};
-
-tsMarkdown([entry], {
-  renderers: getRenderers({
-    bold: (entry: { bold: string }) => {
-      return `🐢🐢${entry.bold}🐢🐢`;
-    },
-  }),
-});
-```
-
-And the result is:
-
-```md
-🐢🐢I can be a professional turtle if I want.🐢🐢
-```
-
-> Enjoy the possibilities 🌌🐢
-
-### Remarks on Extensibility
-
-The current API involves settings things up in stages. It's not as brief as I would like, but it's well-suited for larger-scale document rendering where the same options are used for hundreds or thousands of calls to `tsMarkdown()`. It's largely designed so that other projects can pull in ts-markdown and thoroughly extend and customize it for their purposes, using multiple files and organizing the information in a way that fits their needs.
-
-If you have an idea 💡 for making this extensibility API leaner, cleaner, and easier to read, see [how to contribute](https://github.com/kgar/data-driven-markdown/blob/main/CONTRIBUTING.md).
+**ts-markdown** is written in TypeScript and node JS. It works with node JS v16.x and higher. Earlier versions may also work, but it is not guaranteed.
 
 ## Why This Project?
 

--- a/docs/functions/appendFootnotes.html
+++ b/docs/functions/appendFootnotes.html
@@ -187,7 +187,7 @@
                   <li>
                     Defined in
                     <a
-                      href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/footnote.ts#L52"
+                      href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/footnote.ts#L52"
                       >renderers/footnote.ts:52</a
                     >
                   </li>

--- a/docs/functions/blockquote.html
+++ b/docs/functions/blockquote.html
@@ -194,7 +194,7 @@
                   <li>
                     Defined in
                     <a
-                      href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/blockquote.ts#L50"
+                      href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/blockquote.ts#L50"
                       >renderers/blockquote.ts:50</a
                     >
                   </li>

--- a/docs/functions/blockquoteRenderer.html
+++ b/docs/functions/blockquoteRenderer.html
@@ -171,7 +171,7 @@
                   <li>
                     Defined in
                     <a
-                      href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/rendering.types.ts#L145"
+                      href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/rendering.types.ts#L145"
                       >rendering.types.ts:145</a
                     >
                   </li>

--- a/docs/functions/bold.html
+++ b/docs/functions/bold.html
@@ -185,7 +185,7 @@
                   <li>
                     Defined in
                     <a
-                      href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/bold.ts#L49"
+                      href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/bold.ts#L49"
                       >renderers/bold.ts:49</a
                     >
                   </li>

--- a/docs/functions/boldRenderer.html
+++ b/docs/functions/boldRenderer.html
@@ -170,7 +170,7 @@
                   <li>
                     Defined in
                     <a
-                      href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/rendering.types.ts#L145"
+                      href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/rendering.types.ts#L145"
                       >rendering.types.ts:145</a
                     >
                   </li>

--- a/docs/functions/code.html
+++ b/docs/functions/code.html
@@ -176,7 +176,7 @@
                   <li>
                     Defined in
                     <a
-                      href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/code.ts#L49"
+                      href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/code.ts#L49"
                       >renderers/code.ts:49</a
                     >
                   </li>

--- a/docs/functions/codeRenderer.html
+++ b/docs/functions/codeRenderer.html
@@ -170,7 +170,7 @@
                   <li>
                     Defined in
                     <a
-                      href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/rendering.types.ts#L145"
+                      href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/rendering.types.ts#L145"
                       >rendering.types.ts:145</a
                     >
                   </li>

--- a/docs/functions/codeblock.html
+++ b/docs/functions/codeblock.html
@@ -186,7 +186,7 @@
                   <li>
                     Defined in
                     <a
-                      href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/codeblock.ts#L86"
+                      href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/codeblock.ts#L86"
                       >renderers/codeblock.ts:86</a
                     >
                   </li>

--- a/docs/functions/codeblockRenderer.html
+++ b/docs/functions/codeblockRenderer.html
@@ -170,7 +170,7 @@
                   <li>
                     Defined in
                     <a
-                      href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/rendering.types.ts#L145"
+                      href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/rendering.types.ts#L145"
                       >rendering.types.ts:145</a
                     >
                   </li>

--- a/docs/functions/dl.html
+++ b/docs/functions/dl.html
@@ -202,7 +202,7 @@
                   <li>
                     Defined in
                     <a
-                      href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/dl.ts#L112"
+                      href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/dl.ts#L112"
                       >renderers/dl.ts:112</a
                     >
                   </li>

--- a/docs/functions/dlRenderer.html
+++ b/docs/functions/dlRenderer.html
@@ -170,7 +170,7 @@
                   <li>
                     Defined in
                     <a
-                      href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/rendering.types.ts#L145"
+                      href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/rendering.types.ts#L145"
                       >rendering.types.ts:145</a
                     >
                   </li>

--- a/docs/functions/emoji.html
+++ b/docs/functions/emoji.html
@@ -176,7 +176,7 @@
                   <li>
                     Defined in
                     <a
-                      href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/emoji.ts#L38"
+                      href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/emoji.ts#L38"
                       >renderers/emoji.ts:38</a
                     >
                   </li>

--- a/docs/functions/emojiRenderer.html
+++ b/docs/functions/emojiRenderer.html
@@ -170,7 +170,7 @@
                   <li>
                     Defined in
                     <a
-                      href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/rendering.types.ts#L145"
+                      href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/rendering.types.ts#L145"
                       >rendering.types.ts:145</a
                     >
                   </li>

--- a/docs/functions/footnote.html
+++ b/docs/functions/footnote.html
@@ -209,7 +209,7 @@
                   <li>
                     Defined in
                     <a
-                      href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/footnote.ts#L107"
+                      href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/footnote.ts#L107"
                       >renderers/footnote.ts:107</a
                     >
                   </li>

--- a/docs/functions/footnoteRenderer.html
+++ b/docs/functions/footnoteRenderer.html
@@ -170,7 +170,7 @@
                   <li>
                     Defined in
                     <a
-                      href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/rendering.types.ts#L145"
+                      href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/rendering.types.ts#L145"
                       >rendering.types.ts:145</a
                     >
                   </li>

--- a/docs/functions/getMarkdownString.html
+++ b/docs/functions/getMarkdownString.html
@@ -190,7 +190,7 @@
                   <li>
                     Defined in
                     <a
-                      href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/rendering.ts#L128"
+                      href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/rendering.ts#L128"
                       >rendering.ts:128</a
                     >
                   </li>

--- a/docs/functions/getOptionalHeaderIdText.html
+++ b/docs/functions/getOptionalHeaderIdText.html
@@ -164,7 +164,7 @@
                   <li>
                     Defined in
                     <a
-                      href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/header.ts#L15"
+                      href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/header.ts#L15"
                       >renderers/header.ts:15</a
                     >
                   </li>

--- a/docs/functions/getRenderers.html
+++ b/docs/functions/getRenderers.html
@@ -172,7 +172,7 @@
                   <li>
                     Defined in
                     <a
-                      href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/defaults.ts#L38"
+                      href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/defaults.ts#L38"
                       >defaults.ts:38</a
                     >
                   </li>

--- a/docs/functions/h1.html
+++ b/docs/functions/h1.html
@@ -185,7 +185,7 @@
                   <li>
                     Defined in
                     <a
-                      href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/h1.ts#L71"
+                      href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/h1.ts#L71"
                       >renderers/h1.ts:71</a
                     >
                   </li>

--- a/docs/functions/h1Renderer.html
+++ b/docs/functions/h1Renderer.html
@@ -170,7 +170,7 @@
                   <li>
                     Defined in
                     <a
-                      href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/rendering.types.ts#L145"
+                      href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/rendering.types.ts#L145"
                       >rendering.types.ts:145</a
                     >
                   </li>

--- a/docs/functions/h2.html
+++ b/docs/functions/h2.html
@@ -185,7 +185,7 @@
                   <li>
                     Defined in
                     <a
-                      href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/h2.ts#L71"
+                      href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/h2.ts#L71"
                       >renderers/h2.ts:71</a
                     >
                   </li>

--- a/docs/functions/h2Renderer.html
+++ b/docs/functions/h2Renderer.html
@@ -170,7 +170,7 @@
                   <li>
                     Defined in
                     <a
-                      href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/rendering.types.ts#L145"
+                      href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/rendering.types.ts#L145"
                       >rendering.types.ts:145</a
                     >
                   </li>

--- a/docs/functions/h3.html
+++ b/docs/functions/h3.html
@@ -185,7 +185,7 @@
                   <li>
                     Defined in
                     <a
-                      href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/h3.ts#L60"
+                      href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/h3.ts#L60"
                       >renderers/h3.ts:60</a
                     >
                   </li>

--- a/docs/functions/h3Renderer.html
+++ b/docs/functions/h3Renderer.html
@@ -170,7 +170,7 @@
                   <li>
                     Defined in
                     <a
-                      href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/rendering.types.ts#L145"
+                      href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/rendering.types.ts#L145"
                       >rendering.types.ts:145</a
                     >
                   </li>

--- a/docs/functions/h4.html
+++ b/docs/functions/h4.html
@@ -185,7 +185,7 @@
                   <li>
                     Defined in
                     <a
-                      href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/h4.ts#L60"
+                      href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/h4.ts#L60"
                       >renderers/h4.ts:60</a
                     >
                   </li>

--- a/docs/functions/h4Renderer.html
+++ b/docs/functions/h4Renderer.html
@@ -170,7 +170,7 @@
                   <li>
                     Defined in
                     <a
-                      href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/rendering.types.ts#L145"
+                      href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/rendering.types.ts#L145"
                       >rendering.types.ts:145</a
                     >
                   </li>

--- a/docs/functions/h5.html
+++ b/docs/functions/h5.html
@@ -185,7 +185,7 @@
                   <li>
                     Defined in
                     <a
-                      href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/h5.ts#L60"
+                      href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/h5.ts#L60"
                       >renderers/h5.ts:60</a
                     >
                   </li>

--- a/docs/functions/h5Renderer.html
+++ b/docs/functions/h5Renderer.html
@@ -170,7 +170,7 @@
                   <li>
                     Defined in
                     <a
-                      href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/rendering.types.ts#L145"
+                      href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/rendering.types.ts#L145"
                       >rendering.types.ts:145</a
                     >
                   </li>

--- a/docs/functions/h6.html
+++ b/docs/functions/h6.html
@@ -185,7 +185,7 @@
                   <li>
                     Defined in
                     <a
-                      href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/h6.ts#L60"
+                      href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/h6.ts#L60"
                       >renderers/h6.ts:60</a
                     >
                   </li>

--- a/docs/functions/h6Renderer.html
+++ b/docs/functions/h6Renderer.html
@@ -170,7 +170,7 @@
                   <li>
                     Defined in
                     <a
-                      href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/rendering.types.ts#L145"
+                      href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/rendering.types.ts#L145"
                       >rendering.types.ts:145</a
                     >
                   </li>

--- a/docs/functions/header.html
+++ b/docs/functions/header.html
@@ -367,7 +367,7 @@
                   <li>
                     Defined in
                     <a
-                      href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/header.ts#L26"
+                      href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/header.ts#L26"
                       >renderers/header.ts:26</a
                     >
                   </li>

--- a/docs/functions/highlight.html
+++ b/docs/functions/highlight.html
@@ -189,7 +189,7 @@
                   <li>
                     Defined in
                     <a
-                      href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/highlight.ts#L39"
+                      href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/highlight.ts#L39"
                       >renderers/highlight.ts:39</a
                     >
                   </li>

--- a/docs/functions/highlightRenderer.html
+++ b/docs/functions/highlightRenderer.html
@@ -170,7 +170,7 @@
                   <li>
                     Defined in
                     <a
-                      href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/rendering.types.ts#L145"
+                      href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/rendering.types.ts#L145"
                       >rendering.types.ts:145</a
                     >
                   </li>

--- a/docs/functions/hr.html
+++ b/docs/functions/hr.html
@@ -168,7 +168,7 @@
                   <li>
                     Defined in
                     <a
-                      href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/hr.ts#L54"
+                      href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/hr.ts#L54"
                       >renderers/hr.ts:54</a
                     >
                   </li>

--- a/docs/functions/hrRenderer.html
+++ b/docs/functions/hrRenderer.html
@@ -170,7 +170,7 @@
                   <li>
                     Defined in
                     <a
-                      href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/rendering.types.ts#L145"
+                      href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/rendering.types.ts#L145"
                       >rendering.types.ts:145</a
                     >
                   </li>

--- a/docs/functions/img.html
+++ b/docs/functions/img.html
@@ -199,7 +199,7 @@
                   <li>
                     Defined in
                     <a
-                      href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/img.ts#L52"
+                      href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/img.ts#L52"
                       >renderers/img.ts:52</a
                     >
                   </li>

--- a/docs/functions/imgRenderer.html
+++ b/docs/functions/imgRenderer.html
@@ -170,7 +170,7 @@
                   <li>
                     Defined in
                     <a
-                      href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/rendering.types.ts#L145"
+                      href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/rendering.types.ts#L145"
                       >rendering.types.ts:145</a
                     >
                   </li>

--- a/docs/functions/italic.html
+++ b/docs/functions/italic.html
@@ -176,7 +176,7 @@
                   <li>
                     Defined in
                     <a
-                      href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/italic.ts#L43"
+                      href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/italic.ts#L43"
                       >renderers/italic.ts:43</a
                     >
                   </li>

--- a/docs/functions/italicRenderer.html
+++ b/docs/functions/italicRenderer.html
@@ -170,7 +170,7 @@
                   <li>
                     Defined in
                     <a
-                      href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/rendering.types.ts#L145"
+                      href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/rendering.types.ts#L145"
                       >rendering.types.ts:145</a
                     >
                   </li>

--- a/docs/functions/link.html
+++ b/docs/functions/link.html
@@ -203,7 +203,7 @@
                   <li>
                     Defined in
                     <a
-                      href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/link.ts#L58"
+                      href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/link.ts#L58"
                       >renderers/link.ts:58</a
                     >
                   </li>

--- a/docs/functions/linkRenderer.html
+++ b/docs/functions/linkRenderer.html
@@ -170,7 +170,7 @@
                   <li>
                     Defined in
                     <a
-                      href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/rendering.types.ts#L145"
+                      href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/rendering.types.ts#L145"
                       >rendering.types.ts:145</a
                     >
                   </li>

--- a/docs/functions/ol.html
+++ b/docs/functions/ol.html
@@ -187,7 +187,7 @@
                   <li>
                     Defined in
                     <a
-                      href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/ol.ts#L62"
+                      href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/ol.ts#L62"
                       >renderers/ol.ts:62</a
                     >
                   </li>

--- a/docs/functions/olRenderer.html
+++ b/docs/functions/olRenderer.html
@@ -170,7 +170,7 @@
                   <li>
                     Defined in
                     <a
-                      href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/rendering.types.ts#L145"
+                      href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/rendering.types.ts#L145"
                       >rendering.types.ts:145</a
                     >
                   </li>

--- a/docs/functions/p.html
+++ b/docs/functions/p.html
@@ -176,7 +176,7 @@
                   <li>
                     Defined in
                     <a
-                      href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/p.ts#L71"
+                      href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/p.ts#L71"
                       >renderers/p.ts:71</a
                     >
                   </li>

--- a/docs/functions/pRenderer.html
+++ b/docs/functions/pRenderer.html
@@ -170,7 +170,7 @@
                   <li>
                     Defined in
                     <a
-                      href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/rendering.types.ts#L145"
+                      href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/rendering.types.ts#L145"
                       >rendering.types.ts:145</a
                     >
                   </li>

--- a/docs/functions/renderEntries.html
+++ b/docs/functions/renderEntries.html
@@ -176,7 +176,7 @@
                   <li>
                     Defined in
                     <a
-                      href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/rendering.ts#L71"
+                      href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/rendering.ts#L71"
                       >rendering.ts:71</a
                     >
                   </li>

--- a/docs/functions/strikethrough.html
+++ b/docs/functions/strikethrough.html
@@ -188,7 +188,7 @@
                   <li>
                     Defined in
                     <a
-                      href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/strikethrough.ts#L39"
+                      href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/strikethrough.ts#L39"
                       >renderers/strikethrough.ts:39</a
                     >
                   </li>

--- a/docs/functions/strikethroughRenderer.html
+++ b/docs/functions/strikethroughRenderer.html
@@ -176,7 +176,7 @@
                   <li>
                     Defined in
                     <a
-                      href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/rendering.types.ts#L145"
+                      href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/rendering.types.ts#L145"
                       >rendering.types.ts:145</a
                     >
                   </li>

--- a/docs/functions/stringRenderer.html
+++ b/docs/functions/stringRenderer.html
@@ -167,7 +167,7 @@
                   <li>
                     Defined in
                     <a
-                      href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/rendering.types.ts#L145"
+                      href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/rendering.types.ts#L145"
                       >rendering.types.ts:145</a
                     >
                   </li>

--- a/docs/functions/sub.html
+++ b/docs/functions/sub.html
@@ -185,7 +185,7 @@
                   <li>
                     Defined in
                     <a
-                      href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/sub.ts#L51"
+                      href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/sub.ts#L51"
                       >renderers/sub.ts:51</a
                     >
                   </li>

--- a/docs/functions/subRenderer.html
+++ b/docs/functions/subRenderer.html
@@ -170,7 +170,7 @@
                   <li>
                     Defined in
                     <a
-                      href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/rendering.types.ts#L145"
+                      href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/rendering.types.ts#L145"
                       >rendering.types.ts:145</a
                     >
                   </li>

--- a/docs/functions/sup.html
+++ b/docs/functions/sup.html
@@ -185,7 +185,7 @@
                   <li>
                     Defined in
                     <a
-                      href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/sup.ts#L51"
+                      href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/sup.ts#L51"
                       >renderers/sup.ts:51</a
                     >
                   </li>

--- a/docs/functions/supRenderer.html
+++ b/docs/functions/supRenderer.html
@@ -170,7 +170,7 @@
                   <li>
                     Defined in
                     <a
-                      href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/rendering.types.ts#L145"
+                      href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/rendering.types.ts#L145"
                       >rendering.types.ts:145</a
                     >
                   </li>

--- a/docs/functions/table.html
+++ b/docs/functions/table.html
@@ -285,7 +285,7 @@
                   <li>
                     Defined in
                     <a
-                      href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/table.ts#L278"
+                      href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/table.ts#L278"
                       >renderers/table.ts:278</a
                     >
                   </li>

--- a/docs/functions/tableRenderer.html
+++ b/docs/functions/tableRenderer.html
@@ -170,7 +170,7 @@
                   <li>
                     Defined in
                     <a
-                      href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/rendering.types.ts#L145"
+                      href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/rendering.types.ts#L145"
                       >rendering.types.ts:145</a
                     >
                   </li>

--- a/docs/functions/tasks.html
+++ b/docs/functions/tasks.html
@@ -202,7 +202,7 @@
                   <li>
                     Defined in
                     <a
-                      href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/tasks.ts#L97"
+                      href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/tasks.ts#L97"
                       >renderers/tasks.ts:97</a
                     >
                   </li>

--- a/docs/functions/tasksRenderer.html
+++ b/docs/functions/tasksRenderer.html
@@ -170,7 +170,7 @@
                   <li>
                     Defined in
                     <a
-                      href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/rendering.types.ts#L145"
+                      href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/rendering.types.ts#L145"
                       >rendering.types.ts:145</a
                     >
                   </li>

--- a/docs/functions/text.html
+++ b/docs/functions/text.html
@@ -194,7 +194,7 @@
                   <li>
                     Defined in
                     <a
-                      href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/text.ts#L43"
+                      href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/text.ts#L43"
                       >renderers/text.ts:43</a
                     >
                   </li>

--- a/docs/functions/textRenderer.html
+++ b/docs/functions/textRenderer.html
@@ -170,7 +170,7 @@
                   <li>
                     Defined in
                     <a
-                      href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/rendering.types.ts#L145"
+                      href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/rendering.types.ts#L145"
                       >rendering.types.ts:145</a
                     >
                   </li>

--- a/docs/functions/tsMarkdown.html
+++ b/docs/functions/tsMarkdown.html
@@ -183,7 +183,7 @@
                   <li>
                     Defined in
                     <a
-                      href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/rendering.ts#L17"
+                      href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/rendering.ts#L17"
                       >rendering.ts:17</a
                     >
                   </li>

--- a/docs/functions/ul.html
+++ b/docs/functions/ul.html
@@ -187,7 +187,7 @@
                   <li>
                     Defined in
                     <a
-                      href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/ul.ts#L81"
+                      href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/ul.ts#L81"
                       >renderers/ul.ts:81</a
                     >
                   </li>

--- a/docs/functions/ulRenderer.html
+++ b/docs/functions/ulRenderer.html
@@ -170,7 +170,7 @@
                   <li>
                     Defined in
                     <a
-                      href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/rendering.types.ts#L145"
+                      href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/rendering.types.ts#L145"
                       >rendering.types.ts:145</a
                     >
                   </li>

--- a/docs/interfaces/BlockquoteEntry.html
+++ b/docs/interfaces/BlockquoteEntry.html
@@ -101,7 +101,7 @@
             <li>
               Defined in
               <a
-                href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/blockquote.ts#L8"
+                href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/blockquote.ts#L8"
                 >renderers/blockquote.ts:8</a
               >
             </li>
@@ -226,7 +226,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/blockquote.ts#L17"
+                    href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/blockquote.ts#L17"
                     >renderers/blockquote.ts:17</a
                   >
                 </li>
@@ -279,7 +279,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/blockquote.ts#L12"
+                    href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/blockquote.ts#L12"
                     >renderers/blockquote.ts:12</a
                   >
                 </li>

--- a/docs/interfaces/BoldEntry.html
+++ b/docs/interfaces/BoldEntry.html
@@ -109,7 +109,7 @@
             <li>
               Defined in
               <a
-                href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/bold.ts#L8"
+                href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/bold.ts#L8"
                 >renderers/bold.ts:8</a
               >
             </li>
@@ -238,7 +238,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/bold.ts#L12"
+                    href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/bold.ts#L12"
                     >renderers/bold.ts:12</a
                   >
                 </li>
@@ -284,7 +284,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/bold.ts#L17"
+                    href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/bold.ts#L17"
                     >renderers/bold.ts:17</a
                   >
                 </li>

--- a/docs/interfaces/CodeBlockEntry.html
+++ b/docs/interfaces/CodeBlockEntry.html
@@ -101,7 +101,7 @@
             <li>
               Defined in
               <a
-                href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/codeblock.ts#L7"
+                href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/codeblock.ts#L7"
                 >renderers/codeblock.ts:7</a
               >
             </li>
@@ -252,7 +252,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/codeblock.ts#L27"
+                    href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/codeblock.ts#L27"
                     >renderers/codeblock.ts:27</a
                   >
                 </li>
@@ -298,7 +298,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/codeblock.ts#L11"
+                    href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/codeblock.ts#L11"
                     >renderers/codeblock.ts:11</a
                   >
                 </li>
@@ -346,7 +346,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/codeblock.ts#L17"
+                    href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/codeblock.ts#L17"
                     >renderers/codeblock.ts:17</a
                   >
                 </li>
@@ -393,7 +393,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/codeblock.ts#L22"
+                    href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/codeblock.ts#L22"
                     >renderers/codeblock.ts:22</a
                   >
                 </li>

--- a/docs/interfaces/CodeEntry.html
+++ b/docs/interfaces/CodeEntry.html
@@ -101,7 +101,7 @@
             <li>
               Defined in
               <a
-                href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/code.ts#L7"
+                href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/code.ts#L7"
                 >renderers/code.ts:7</a
               >
             </li>
@@ -207,7 +207,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/code.ts#L11"
+                    href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/code.ts#L11"
                     >renderers/code.ts:11</a
                   >
                 </li>

--- a/docs/interfaces/DescriptionListEntry.html
+++ b/docs/interfaces/DescriptionListEntry.html
@@ -103,7 +103,7 @@
             <li>
               Defined in
               <a
-                href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/dl.ts#L8"
+                href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/dl.ts#L8"
                 >renderers/dl.ts:8</a
               >
             </li>
@@ -241,7 +241,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/dl.ts#L23"
+                    href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/dl.ts#L23"
                     >renderers/dl.ts:23</a
                   >
                 </li>
@@ -297,7 +297,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/dl.ts#L12"
+                    href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/dl.ts#L12"
                     >renderers/dl.ts:12</a
                   >
                 </li>
@@ -341,7 +341,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/dl.ts#L18"
+                    href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/dl.ts#L18"
                     >renderers/dl.ts:18</a
                   >
                 </li>

--- a/docs/interfaces/EmojiEntry.html
+++ b/docs/interfaces/EmojiEntry.html
@@ -109,7 +109,7 @@
             <li>
               Defined in
               <a
-                href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/emoji.ts#L7"
+                href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/emoji.ts#L7"
                 >renderers/emoji.ts:7</a
               >
             </li>
@@ -215,7 +215,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/emoji.ts#L11"
+                    href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/emoji.ts#L11"
                     >renderers/emoji.ts:11</a
                   >
                 </li>

--- a/docs/interfaces/FootnoteEntry.html
+++ b/docs/interfaces/FootnoteEntry.html
@@ -109,7 +109,7 @@
             <li>
               Defined in
               <a
-                href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/footnote.ts#L8"
+                href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/footnote.ts#L8"
                 >renderers/footnote.ts:8</a
               >
             </li>
@@ -282,7 +282,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/footnote.ts#L12"
+                    href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/footnote.ts#L12"
                     >renderers/footnote.ts:12</a
                   >
                 </li>

--- a/docs/interfaces/H1Entry.html
+++ b/docs/interfaces/H1Entry.html
@@ -101,7 +101,7 @@
             <li>
               Defined in
               <a
-                href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/h1.ts#L9"
+                href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/h1.ts#L9"
                 >renderers/h1.ts:9</a
               >
             </li>
@@ -252,7 +252,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/h1.ts#L30"
+                    href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/h1.ts#L30"
                     >renderers/h1.ts:30</a
                   >
                 </li>
@@ -297,7 +297,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/h1.ts#L13"
+                    href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/h1.ts#L13"
                     >renderers/h1.ts:13</a
                   >
                 </li>
@@ -342,7 +342,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/h1.ts#L25"
+                    href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/h1.ts#L25"
                     >renderers/h1.ts:25</a
                   >
                 </li>
@@ -389,7 +389,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/h1.ts#L18"
+                    href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/h1.ts#L18"
                     >renderers/h1.ts:18</a
                   >
                 </li>

--- a/docs/interfaces/H2Entry.html
+++ b/docs/interfaces/H2Entry.html
@@ -101,7 +101,7 @@
             <li>
               Defined in
               <a
-                href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/h2.ts#L9"
+                href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/h2.ts#L9"
                 >renderers/h2.ts:9</a
               >
             </li>
@@ -252,7 +252,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/h2.ts#L30"
+                    href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/h2.ts#L30"
                     >renderers/h2.ts:30</a
                   >
                 </li>
@@ -297,7 +297,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/h2.ts#L13"
+                    href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/h2.ts#L13"
                     >renderers/h2.ts:13</a
                   >
                 </li>
@@ -342,7 +342,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/h2.ts#L25"
+                    href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/h2.ts#L25"
                     >renderers/h2.ts:25</a
                   >
                 </li>
@@ -389,7 +389,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/h2.ts#L18"
+                    href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/h2.ts#L18"
                     >renderers/h2.ts:18</a
                   >
                 </li>

--- a/docs/interfaces/H3Entry.html
+++ b/docs/interfaces/H3Entry.html
@@ -101,7 +101,7 @@
             <li>
               Defined in
               <a
-                href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/h3.ts#L9"
+                href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/h3.ts#L9"
                 >renderers/h3.ts:9</a
               >
             </li>
@@ -239,7 +239,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/h3.ts#L25"
+                    href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/h3.ts#L25"
                     >renderers/h3.ts:25</a
                   >
                 </li>
@@ -284,7 +284,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/h3.ts#L13"
+                    href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/h3.ts#L13"
                     >renderers/h3.ts:13</a
                   >
                 </li>
@@ -329,7 +329,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/h3.ts#L20"
+                    href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/h3.ts#L20"
                     >renderers/h3.ts:20</a
                   >
                 </li>

--- a/docs/interfaces/H4Entry.html
+++ b/docs/interfaces/H4Entry.html
@@ -101,7 +101,7 @@
             <li>
               Defined in
               <a
-                href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/h4.ts#L9"
+                href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/h4.ts#L9"
                 >renderers/h4.ts:9</a
               >
             </li>
@@ -239,7 +239,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/h4.ts#L25"
+                    href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/h4.ts#L25"
                     >renderers/h4.ts:25</a
                   >
                 </li>
@@ -284,7 +284,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/h4.ts#L13"
+                    href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/h4.ts#L13"
                     >renderers/h4.ts:13</a
                   >
                 </li>
@@ -329,7 +329,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/h4.ts#L20"
+                    href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/h4.ts#L20"
                     >renderers/h4.ts:20</a
                   >
                 </li>

--- a/docs/interfaces/H5Entry.html
+++ b/docs/interfaces/H5Entry.html
@@ -101,7 +101,7 @@
             <li>
               Defined in
               <a
-                href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/h5.ts#L9"
+                href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/h5.ts#L9"
                 >renderers/h5.ts:9</a
               >
             </li>
@@ -239,7 +239,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/h5.ts#L25"
+                    href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/h5.ts#L25"
                     >renderers/h5.ts:25</a
                   >
                 </li>
@@ -284,7 +284,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/h5.ts#L13"
+                    href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/h5.ts#L13"
                     >renderers/h5.ts:13</a
                   >
                 </li>
@@ -329,7 +329,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/h5.ts#L20"
+                    href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/h5.ts#L20"
                     >renderers/h5.ts:20</a
                   >
                 </li>

--- a/docs/interfaces/H6Entry.html
+++ b/docs/interfaces/H6Entry.html
@@ -101,7 +101,7 @@
             <li>
               Defined in
               <a
-                href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/h6.ts#L9"
+                href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/h6.ts#L9"
                 >renderers/h6.ts:9</a
               >
             </li>
@@ -239,7 +239,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/h6.ts#L25"
+                    href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/h6.ts#L25"
                     >renderers/h6.ts:25</a
                   >
                 </li>
@@ -284,7 +284,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/h6.ts#L13"
+                    href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/h6.ts#L13"
                     >renderers/h6.ts:13</a
                   >
                 </li>
@@ -329,7 +329,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/h6.ts#L20"
+                    href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/h6.ts#L20"
                     >renderers/h6.ts:20</a
                   >
                 </li>

--- a/docs/interfaces/HighlightEntry.html
+++ b/docs/interfaces/HighlightEntry.html
@@ -109,7 +109,7 @@
             <li>
               Defined in
               <a
-                href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/highlight.ts#L8"
+                href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/highlight.ts#L8"
                 >renderers/highlight.ts:8</a
               >
             </li>
@@ -228,7 +228,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/highlight.ts#L12"
+                    href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/highlight.ts#L12"
                     >renderers/highlight.ts:12</a
                   >
                 </li>

--- a/docs/interfaces/HorizontalRuleEntry.html
+++ b/docs/interfaces/HorizontalRuleEntry.html
@@ -101,7 +101,7 @@
             <li>
               Defined in
               <a
-                href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/hr.ts#L7"
+                href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/hr.ts#L7"
                 >renderers/hr.ts:7</a
               >
             </li>
@@ -239,7 +239,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/hr.ts#L22"
+                    href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/hr.ts#L22"
                     >renderers/hr.ts:22</a
                   >
                 </li>
@@ -279,7 +279,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/hr.ts#L11"
+                    href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/hr.ts#L11"
                     >renderers/hr.ts:11</a
                   >
                 </li>
@@ -330,7 +330,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/hr.ts#L17"
+                    href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/hr.ts#L17"
                     >renderers/hr.ts:17</a
                   >
                 </li>

--- a/docs/interfaces/ImageEntry.html
+++ b/docs/interfaces/ImageEntry.html
@@ -101,7 +101,7 @@
             <li>
               Defined in
               <a
-                href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/img.ts#L7"
+                href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/img.ts#L7"
                 >renderers/img.ts:7</a
               >
             </li>
@@ -258,7 +258,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/img.ts#L11"
+                    href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/img.ts#L11"
                     >renderers/img.ts:11</a
                   >
                 </li>

--- a/docs/interfaces/InlineTypes.html
+++ b/docs/interfaces/InlineTypes.html
@@ -114,7 +114,7 @@
             <li>
               Defined in
               <a
-                href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/shared.types.ts#L14"
+                href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/shared.types.ts#L14"
                 >shared.types.ts:14</a
               >
             </li>

--- a/docs/interfaces/ItalicEntry.html
+++ b/docs/interfaces/ItalicEntry.html
@@ -109,7 +109,7 @@
             <li>
               Defined in
               <a
-                href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/italic.ts#L8"
+                href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/italic.ts#L8"
                 >renderers/italic.ts:8</a
               >
             </li>
@@ -239,7 +239,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/italic.ts#L18"
+                    href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/italic.ts#L18"
                     >renderers/italic.ts:18</a
                   >
                 </li>
@@ -287,7 +287,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/italic.ts#L12"
+                    href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/italic.ts#L12"
                     >renderers/italic.ts:12</a
                   >
                 </li>

--- a/docs/interfaces/LinkEntry.html
+++ b/docs/interfaces/LinkEntry.html
@@ -101,7 +101,7 @@
             <li>
               Defined in
               <a
-                href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/link.ts#L7"
+                href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/link.ts#L7"
                 >renderers/link.ts:7</a
               >
             </li>
@@ -261,7 +261,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/link.ts#L11"
+                    href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/link.ts#L11"
                     >renderers/link.ts:11</a
                   >
                 </li>

--- a/docs/interfaces/MarkdownEntry.html
+++ b/docs/interfaces/MarkdownEntry.html
@@ -306,7 +306,7 @@
             <li>
               Defined in
               <a
-                href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/shared.types.ts#L4"
+                href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/shared.types.ts#L4"
                 >shared.types.ts:4</a
               >
             </li>

--- a/docs/interfaces/MarkdownRenderer.html
+++ b/docs/interfaces/MarkdownRenderer.html
@@ -172,7 +172,7 @@
                   <li>
                     Defined in
                     <a
-                      href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/rendering.types.ts#L145"
+                      href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/rendering.types.ts#L145"
                       >rendering.types.ts:145</a
                     >
                   </li>

--- a/docs/interfaces/OrderedListEntry.html
+++ b/docs/interfaces/OrderedListEntry.html
@@ -101,7 +101,7 @@
             <li>
               Defined in
               <a
-                href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/ol.ts#L8"
+                href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/ol.ts#L8"
                 >renderers/ol.ts:8</a
               >
             </li>
@@ -226,7 +226,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/ol.ts#L17"
+                    href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/ol.ts#L17"
                     >renderers/ol.ts:17</a
                   >
                 </li>
@@ -274,7 +274,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/ol.ts#L12"
+                    href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/ol.ts#L12"
                     >renderers/ol.ts:12</a
                   >
                 </li>

--- a/docs/interfaces/ParagraphEntry.html
+++ b/docs/interfaces/ParagraphEntry.html
@@ -101,7 +101,7 @@
             <li>
               Defined in
               <a
-                href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/p.ts#L8"
+                href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/p.ts#L8"
                 >renderers/p.ts:8</a
               >
             </li>
@@ -226,7 +226,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/p.ts#L17"
+                    href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/p.ts#L17"
                     >renderers/p.ts:17</a
                   >
                 </li>
@@ -274,7 +274,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/p.ts#L12"
+                    href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/p.ts#L12"
                     >renderers/p.ts:12</a
                   >
                 </li>

--- a/docs/interfaces/RenderOptions.html
+++ b/docs/interfaces/RenderOptions.html
@@ -95,7 +95,7 @@
             <li>
               Defined in
               <a
-                href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/rendering.types.ts#L32"
+                href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/rendering.types.ts#L32"
                 >rendering.types.ts:32</a
               >
             </li>
@@ -373,7 +373,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/rendering.types.ts#L131"
+                    href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/rendering.types.ts#L131"
                     >rendering.types.ts:131</a
                   >
                 </li>
@@ -421,7 +421,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/rendering.types.ts#L136"
+                    href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/rendering.types.ts#L136"
                     >rendering.types.ts:136</a
                   >
                 </li>
@@ -567,7 +567,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/rendering.types.ts#L103"
+                    href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/rendering.types.ts#L103"
                     >rendering.types.ts:103</a
                   >
                 </li>
@@ -713,7 +713,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/rendering.types.ts#L82"
+                    href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/rendering.types.ts#L82"
                     >rendering.types.ts:82</a
                   >
                 </li>
@@ -764,7 +764,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/rendering.types.ts#L71"
+                    href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/rendering.types.ts#L71"
                     >rendering.types.ts:71</a
                   >
                 </li>
@@ -816,7 +816,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/rendering.types.ts#L76"
+                    href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/rendering.types.ts#L76"
                     >rendering.types.ts:76</a
                   >
                 </li>
@@ -871,7 +871,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/rendering.types.ts#L37"
+                    href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/rendering.types.ts#L37"
                     >rendering.types.ts:37</a
                   >
                 </li>
@@ -929,7 +929,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/rendering.types.ts#L126"
+                    href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/rendering.types.ts#L126"
                     >rendering.types.ts:126</a
                   >
                 </li>
@@ -976,7 +976,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/rendering.types.ts#L65"
+                    href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/rendering.types.ts#L65"
                     >rendering.types.ts:65</a
                   >
                 </li>
@@ -1025,7 +1025,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/rendering.types.ts#L42"
+                    href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/rendering.types.ts#L42"
                     >rendering.types.ts:42</a
                   >
                 </li>
@@ -1074,7 +1074,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/rendering.types.ts#L47"
+                    href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/rendering.types.ts#L47"
                     >rendering.types.ts:47</a
                   >
                 </li>
@@ -1122,7 +1122,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/rendering.types.ts#L53"
+                    href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/rendering.types.ts#L53"
                     >rendering.types.ts:53</a
                   >
                 </li>
@@ -1170,7 +1170,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/rendering.types.ts#L59"
+                    href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/rendering.types.ts#L59"
                     >rendering.types.ts:59</a
                   >
                 </li>

--- a/docs/interfaces/RenderPrefixFunction.html
+++ b/docs/interfaces/RenderPrefixFunction.html
@@ -170,7 +170,7 @@
                   <li>
                     Defined in
                     <a
-                      href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/rendering.types.ts#L10"
+                      href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/rendering.types.ts#L10"
                       >rendering.types.ts:10</a
                     >
                   </li>

--- a/docs/interfaces/Renderers.html
+++ b/docs/interfaces/Renderers.html
@@ -115,7 +115,7 @@
             <li>
               Defined in
               <a
-                href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/rendering.types.ts#L24"
+                href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/rendering.types.ts#L24"
                 >rendering.types.ts:24</a
               >
             </li>

--- a/docs/interfaces/RichTextEntry.html
+++ b/docs/interfaces/RichTextEntry.html
@@ -180,7 +180,7 @@
             <li>
               Defined in
               <a
-                href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/shared.types.ts#L9"
+                href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/shared.types.ts#L9"
                 >shared.types.ts:9</a
               >
             </li>

--- a/docs/interfaces/StrikethroughEntry.html
+++ b/docs/interfaces/StrikethroughEntry.html
@@ -109,7 +109,7 @@
             <li>
               Defined in
               <a
-                href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/strikethrough.ts#L8"
+                href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/strikethrough.ts#L8"
                 >renderers/strikethrough.ts:8</a
               >
             </li>
@@ -228,7 +228,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/strikethrough.ts#L12"
+                    href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/strikethrough.ts#L12"
                     >renderers/strikethrough.ts:12</a
                   >
                 </li>

--- a/docs/interfaces/String.html
+++ b/docs/interfaces/String.html
@@ -104,7 +104,7 @@
             <li>
               Defined in
               <a
-                href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/string.ts#L8"
+                href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/string.ts#L8"
                 >renderers/string.ts:8</a
               >
             </li>

--- a/docs/interfaces/SubscriptEntry.html
+++ b/docs/interfaces/SubscriptEntry.html
@@ -109,7 +109,7 @@
             <li>
               Defined in
               <a
-                href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/sub.ts#L8"
+                href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/sub.ts#L8"
                 >renderers/sub.ts:8</a
               >
             </li>
@@ -234,7 +234,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/sub.ts#L18"
+                    href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/sub.ts#L18"
                     >renderers/sub.ts:18</a
                   >
                 </li>
@@ -282,7 +282,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/sub.ts#L12"
+                    href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/sub.ts#L12"
                     >renderers/sub.ts:12</a
                   >
                 </li>

--- a/docs/interfaces/SuperscriptEntry.html
+++ b/docs/interfaces/SuperscriptEntry.html
@@ -109,7 +109,7 @@
             <li>
               Defined in
               <a
-                href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/sup.ts#L8"
+                href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/sup.ts#L8"
                 >renderers/sup.ts:8</a
               >
             </li>
@@ -234,7 +234,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/sup.ts#L18"
+                    href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/sup.ts#L18"
                     >renderers/sup.ts:18</a
                   >
                 </li>
@@ -282,7 +282,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/sup.ts#L12"
+                    href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/sup.ts#L12"
                     >renderers/sup.ts:12</a
                   >
                 </li>

--- a/docs/interfaces/TableEntry.html
+++ b/docs/interfaces/TableEntry.html
@@ -101,7 +101,7 @@
             <li>
               Defined in
               <a
-                href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/table.ts#L9"
+                href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/table.ts#L9"
                 >renderers/table.ts:9</a
               >
             </li>
@@ -226,7 +226,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/table.ts#L28"
+                    href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/table.ts#L28"
                     >renderers/table.ts:28</a
                   >
                 </li>
@@ -354,7 +354,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/table.ts#L13"
+                    href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/table.ts#L13"
                     >renderers/table.ts:13</a
                   >
                 </li>

--- a/docs/interfaces/TaskListEntry.html
+++ b/docs/interfaces/TaskListEntry.html
@@ -101,7 +101,7 @@
             <li>
               Defined in
               <a
-                href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/tasks.ts#L8"
+                href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/tasks.ts#L8"
                 >renderers/tasks.ts:8</a
               >
             </li>
@@ -226,7 +226,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/tasks.ts#L17"
+                    href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/tasks.ts#L17"
                     >renderers/tasks.ts:17</a
                   >
                 </li>
@@ -281,7 +281,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/tasks.ts#L12"
+                    href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/tasks.ts#L12"
                     >renderers/tasks.ts:12</a
                   >
                 </li>

--- a/docs/interfaces/TextEntry.html
+++ b/docs/interfaces/TextEntry.html
@@ -105,7 +105,7 @@
             <li>
               Defined in
               <a
-                href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/text.ts#L12"
+                href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/text.ts#L12"
                 >renderers/text.ts:12</a
               >
             </li>
@@ -243,7 +243,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/text.ts#L16"
+                    href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/text.ts#L16"
                     >renderers/text.ts:16</a
                   >
                 </li>

--- a/docs/interfaces/UnorderedListEntry.html
+++ b/docs/interfaces/UnorderedListEntry.html
@@ -101,7 +101,7 @@
             <li>
               Defined in
               <a
-                href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/ul.ts#L8"
+                href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/ul.ts#L8"
                 >renderers/ul.ts:8</a
               >
             </li>
@@ -239,7 +239,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/ul.ts#L23"
+                    href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/ul.ts#L23"
                     >renderers/ul.ts:23</a
                   >
                 </li>
@@ -291,7 +291,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/ul.ts#L18"
+                    href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/ul.ts#L18"
                     >renderers/ul.ts:18</a
                   >
                 </li>
@@ -339,7 +339,7 @@
                 <li>
                   Defined in
                   <a
-                    href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/ul.ts#L12"
+                    href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/ul.ts#L12"
                     >renderers/ul.ts:12</a
                   >
                 </li>

--- a/docs/pages/extending-ts-markdown.html
+++ b/docs/pages/extending-ts-markdown.html
@@ -112,6 +112,14 @@
             type of markdown engine, such as
             <a href="https://www.obsidian.md">Obsidian.md</a>.
           </p>
+          <p>
+            If you would like an example of how to extend
+            <strong>ts-markdown</strong> that is not covered here, feel free to
+            <a href="https://github.com/kgar/ts-markdown/issues/new"
+              >open a new github issue</a
+            >
+            requesting the type of extensibility example you&#39;d like to see.
+          </p>
 
           <a
             href="#a-simple-extension"

--- a/docs/pages/faqs.html
+++ b/docs/pages/faqs.html
@@ -80,6 +80,14 @@
             Coming soon. This page will hold frequently asked questions as they
             emerge.
           </p>
+          <p>
+            If you have a question that you believe would be a frequently asked
+            question, feel free to
+            <a href="https://github.com/kgar/ts-markdown/issues/new"
+              >open a new GitHub issue</a
+            >
+            requesting the question be added to this FAQs page.
+          </p>
         </div>
       </div>
       <div class="col-4 col-menu menu-sticky-wrap menu-highlight">

--- a/docs/pages/options.html
+++ b/docs/pages/options.html
@@ -111,6 +111,14 @@
               type of <code>MarkdownEntry</code>
             </li>
           </ul>
+          <p>
+            If there is additional options information you&#39;d like to see
+            here which wouldn&#39;t fit in FAQs, the cookbook, or the type docs,
+            <a href="https://github.com/kgar/ts-markdown/issues/new"
+              >open a new GitHub issue</a
+            >
+            requesting the type of options documentation you&#39;d like to see.
+          </p>
 
           <a
             href="#document-level-options"

--- a/docs/types/DescriptionDetails.html
+++ b/docs/types/DescriptionDetails.html
@@ -114,7 +114,7 @@
             <li>
               Defined in
               <a
-                href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/dl.ts#L39"
+                href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/dl.ts#L39"
                 >renderers/dl.ts:39</a
               >
             </li>

--- a/docs/types/DescriptionTerm.html
+++ b/docs/types/DescriptionTerm.html
@@ -114,7 +114,7 @@
             <li>
               Defined in
               <a
-                href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/dl.ts#L29"
+                href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/dl.ts#L29"
                 >renderers/dl.ts:29</a
               >
             </li>

--- a/docs/types/ListItemEntry.html
+++ b/docs/types/ListItemEntry.html
@@ -100,7 +100,7 @@
             <li>
               Defined in
               <a
-                href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/shared.types.ts#L19"
+                href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/shared.types.ts#L19"
                 >shared.types.ts:19</a
               >
             </li>

--- a/docs/types/MarkdownRenderPrefix.html
+++ b/docs/types/MarkdownRenderPrefix.html
@@ -101,7 +101,7 @@
             <li>
               Defined in
               <a
-                href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/rendering.types.ts#L17"
+                href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/rendering.types.ts#L17"
                 >rendering.types.ts:17</a
               >
             </li>

--- a/docs/types/MarkdownRenderResult.html
+++ b/docs/types/MarkdownRenderResult.html
@@ -107,7 +107,7 @@
             <li>
               Defined in
               <a
-                href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/rendering.types.ts#L153"
+                href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/rendering.types.ts#L153"
                 >rendering.types.ts:153</a
               >
             </li>

--- a/docs/types/TableColumn.html
+++ b/docs/types/TableColumn.html
@@ -128,7 +128,7 @@
             <li>
               Defined in
               <a
-                href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/table.ts#L34"
+                href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/table.ts#L34"
                 >renderers/table.ts:34</a
               >
             </li>

--- a/docs/types/TableRow.html
+++ b/docs/types/TableRow.html
@@ -118,7 +118,7 @@
             <li>
               Defined in
               <a
-                href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/table.ts#L49"
+                href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/table.ts#L49"
                 >renderers/table.ts:49</a
               >
             </li>

--- a/docs/types/TaskEntry.html
+++ b/docs/types/TaskEntry.html
@@ -131,7 +131,7 @@
             <li>
               Defined in
               <a
-                href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/tasks.ts#L23"
+                href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/tasks.ts#L23"
                 >renderers/tasks.ts:23</a
               >
             </li>

--- a/docs/types/UnorderedListItemIndicator.html
+++ b/docs/types/UnorderedListItemIndicator.html
@@ -98,7 +98,7 @@
             <li>
               Defined in
               <a
-                href="https://github.com/kgar/ts-markdown/blob/515f8d2/src/renderers/ul.ts#L29"
+                href="https://github.com/kgar/ts-markdown/blob/188e7b6/src/renderers/ul.ts#L29"
                 >renderers/ul.ts:29</a
               >
             </li>


### PR DESCRIPTION
Trimmed the readme down and refreshed the type docs.

The readme now points to various places in the documentation.

Closes #11 